### PR TITLE
"Compatibility Mode" to force GLES2 to deal with driver bugs

### DIFF
--- a/SS14.Launcher/Models/ConfigurationManager.cs
+++ b/SS14.Launcher/Models/ConfigurationManager.cs
@@ -31,6 +31,7 @@ namespace SS14.Launcher.Models
         private bool _ignoreSave;
         private string? _userName;
         private int _nextInstallationId = 1;
+        private bool _forceGLES2;
 
         public ConfigurationManager()
         {
@@ -68,6 +69,20 @@ namespace SS14.Launcher.Models
 
         public IObservableCache<FavoriteServer, string> FavoriteServers => _favoriteServers;
         public IObservableCache<Installation, string> Installations => _installations;
+
+        /// <summary>
+        ///     If true, whenever SS14 is started, the cvar will be set to force GLES2 rendering. (See Models/Connector.cs:LaunchClient)
+        ///     Otherwise, it'll be set to the default fallback chain.
+        /// </summary>
+        public bool ForceGLES2
+        {
+            get => _forceGLES2;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref _forceGLES2, value);
+                Save();
+            }
+        }
 
         public void AddFavoriteServer(FavoriteServer server)
         {
@@ -146,6 +161,8 @@ namespace SS14.Launcher.Models
                         a.AddOrUpdate(data.Installations);
                     });
                 }
+
+                ForceGLES2 = data.ForceGLES2 ?? false;
             }
             finally
             {
@@ -165,6 +182,7 @@ namespace SS14.Launcher.Models
             var data = JsonConvert.SerializeObject(new JsonData
             {
                 Username = _userName,
+                ForceGLES2 = _forceGLES2,
                 Favorites = _favoriteServers.Items.ToList(),
                 NextInstallationId = _nextInstallationId,
                 Installations = _installations.Items.ToList()
@@ -199,6 +217,9 @@ namespace SS14.Launcher.Models
 
             [JsonProperty(PropertyName = "next_installation_id")]
             public int NextInstallationId { get; set; } = 1;
-        }
+
+            [JsonProperty(PropertyName = "force_gles2")]
+            public bool? ForceGLES2 { get; set; }
+       }
     }
 }

--- a/SS14.Launcher/Models/Connector.cs
+++ b/SS14.Launcher/Models/Connector.cs
@@ -114,6 +114,9 @@ namespace SS14.Launcher.Models
 
                 // ss14(s):// address passed in. Only used for feedback in the client.
                 "--ss14-address", parsedAddress.ToString(),
+
+                // GLES2 forcing or using default fallback
+                "--cvar", "display.renderer=" + (_cfg.ForceGLES2 ? "3" : "0"),
             });
 
             // Wait 300ms, if the client exits with a bad error code before that it's probably fucked.

--- a/SS14.Launcher/ViewModels/MainWindowTabs/OptionsTabViewModel.cs
+++ b/SS14.Launcher/ViewModels/MainWindowTabs/OptionsTabViewModel.cs
@@ -1,7 +1,31 @@
+using System;
+using ReactiveUI;
+using SS14.Launcher.Models;
+using SS14.Launcher.Views;
+
 namespace SS14.Launcher.ViewModels.MainWindowTabs
 {
     public class OptionsTabViewModel : MainWindowTabViewModel
     {
+        public readonly ConfigurationManager Cfg;
+
+        public OptionsTabViewModel(ConfigurationManager cfg)
+        {
+            Cfg = cfg;
+        }
+
+        public bool ForceGLES2
+        {
+            get
+            {
+                return Cfg.ForceGLES2;
+            }
+            set
+            {
+                Cfg.ForceGLES2 = value;
+            }
+        }
+
         public override string Name => "Options";
     }
 }

--- a/SS14.Launcher/ViewModels/MainWindowViewModel.cs
+++ b/SS14.Launcher/ViewModels/MainWindowViewModel.cs
@@ -23,13 +23,15 @@ namespace SS14.Launcher.ViewModels
 
             var servers = new ServerListTabViewModel(cfg, statusCache, updater);
             var news = new NewsTabViewModel();
+            var options = new OptionsTabViewModel();
             var home = new HomePageViewModel(cfg, statusCache, updater);
 
             Tabs = new MainWindowTabViewModel[]
             {
                 home,
                 servers,
-                news
+                news,
+                options
             };
 
             this.WhenAnyValue(x => x.SelectedIndex).Subscribe(i => Tabs[i].Selected());

--- a/SS14.Launcher/ViewModels/MainWindowViewModel.cs
+++ b/SS14.Launcher/ViewModels/MainWindowViewModel.cs
@@ -23,7 +23,7 @@ namespace SS14.Launcher.ViewModels
 
             var servers = new ServerListTabViewModel(cfg, statusCache, updater);
             var news = new NewsTabViewModel();
-            var options = new OptionsTabViewModel();
+            var options = new OptionsTabViewModel(cfg);
             var home = new HomePageViewModel(cfg, statusCache, updater);
 
             Tabs = new MainWindowTabViewModel[]

--- a/SS14.Launcher/Views/MainWindowTabs/OptionsTabView.xaml
+++ b/SS14.Launcher/Views/MainWindowTabs/OptionsTabView.xaml
@@ -11,7 +11,8 @@
         <mainWindowTabs:OptionsTabViewModel />
     </Design.DataContext>
 
-    <Grid Margin="4" VerticalAlignment="Top" ColumnDefinitions="Auto, *">
-        <TextBlock Grid.Column="0" VerticalAlignment="Center" Text="There would be some options here, but that's for another commit." Margin="4" />
-    </Grid>
+    <StackPanel Orientation="Vertical">
+        <CheckBox Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" Margin="4" IsChecked="{Binding ForceGLES2,Mode=TwoWay}">Compatibility Mode</CheckBox>
+        <TextBlock Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" TextWrapping="Wrap" Text="This uses OpenGL ES 2 (via ANGLE if necessary), which is less likely to suffer from driver bugs. Use this if you are experiencing graphical issues." Margin="8" />
+    </StackPanel>
 </UserControl>

--- a/SS14.Launcher/Views/MainWindowTabs/OptionsTabView.xaml
+++ b/SS14.Launcher/Views/MainWindowTabs/OptionsTabView.xaml
@@ -11,12 +11,7 @@
         <mainWindowTabs:OptionsTabViewModel />
     </Design.DataContext>
 
-    <!--<Grid Margin="4" VerticalAlignment="Top" ColumnDefinitions="Auto, *">
-        <TextBlock Grid.Column="0" VerticalAlignment="Center" Text="Player Name:" Margin="4" />
-
-        <DockPanel Grid.Column="1">
-            <Button DockPanel.Dock="Right" Content="Save" Command="{Binding PlayerNameSaveButtonPressed}" />
-            <TextBox Margin="4" VerticalAlignment="Center" Text="{Binding PlayerName,Mode=TwoWay}" />
-        </DockPanel>
-    </Grid>-->
+    <Grid Margin="4" VerticalAlignment="Top" ColumnDefinitions="Auto, *">
+        <TextBlock Grid.Column="0" VerticalAlignment="Center" Text="There would be some options here, but that's for another commit." Margin="4" />
+    </Grid>
 </UserControl>

--- a/SS14.Launcher/Views/MainWindowTabs/OptionsTabView.xaml
+++ b/SS14.Launcher/Views/MainWindowTabs/OptionsTabView.xaml
@@ -12,7 +12,7 @@
     </Design.DataContext>
 
     <StackPanel Orientation="Vertical">
-        <CheckBox Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" Margin="4" IsChecked="{Binding ForceGLES2,Mode=TwoWay}">Compatibility Mode</CheckBox>
-        <TextBlock Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" TextWrapping="Wrap" Text="This uses OpenGL ES 2 (via ANGLE if necessary), which is less likely to suffer from driver bugs. Use this if you are experiencing graphical issues." Margin="8" />
+        <CheckBox VerticalAlignment="Center" Margin="4" IsChecked="{Binding ForceGLES2,Mode=TwoWay}">Compatibility Mode</CheckBox>
+        <TextBlock VerticalAlignment="Center" TextWrapping="Wrap" Text="This uses OpenGL ES 2 (via ANGLE if necessary), which is less likely to suffer from driver bugs. Use this if you are experiencing graphical issues." Margin="8" />
     </StackPanel>
 </UserControl>


### PR DESCRIPTION
This adds a "compatibility mode" checkbox with an explaination of what it does (uses GLES2, presumably via ANGLE, to avoid any driver issues with GL 3) in preparation for when ANGLE enters the releases