### PR TITLE
Fix getting current directory in Linux shell script

### DIFF
--- a/PublishFiles/SS14.Launcher
+++ b/PublishFiles/SS14.Launcher
@@ -1,4 +1,4 @@
 #!/bin/sh
-cd "$(dirname "$(readlink "$0")")"
+cd "$(dirname "$(readlink -f "$0")")"
 export DOTNET_ROOT="$(pwd)/dotnet"
 exec ./bin/SS14.Launcher "$@"


### PR DESCRIPTION
`readlink` without any other arguments fails with files that are not symbolic links and returns empty string

In other words it will only work if:
- the script is executed thru symbolic link
- the script is executed from within the applications directory (the readlink still fails but the working directory is valid for the rest of the script to run)

It does not work when calling the script directly, outside of the directory, eg: `./Downloads/SS14.Launcher`

