### PR TITLE
Infer the presence of "client.zip" on the status host if necessary

### DIFF
--- a/SS14.Launcher/Models/Connector.cs
+++ b/SS14.Launcher/Models/Connector.cs
@@ -204,6 +204,15 @@ public class Connector : ReactiveObject
         {
             var resp = await _http.GetStringAsync(infoAddr, cancel);
             var info = JsonConvert.DeserializeObject<ServerInfo>(resp);
+            if (info.BuildInformation != null)
+            {
+                // Infer download URL to be self-hosted client address if not supplied
+                // (The server may not know it's own address)
+                if (string.IsNullOrEmpty(info.BuildInformation.DownloadUrl))
+                {
+                    info.BuildInformation.DownloadUrl = UriHelper.GetServerSelfhostedClientZipAddress(parsedAddress).ToString();
+                }
+            }
             return (info, parsedAddress, infoAddr);
         }
         catch (Exception e) when (e is JsonException || e is HttpRequestException)

--- a/SS14.Launcher/Models/Updater.cs
+++ b/SS14.Launcher/Models/Updater.cs
@@ -100,6 +100,8 @@ public sealed class Updater : ReactiveObject
 
         Status = UpdateStatus.DownloadingClientUpdate;
 
+        Log.Information($"Downloading content update from {buildInformation.DownloadUrl}");
+
         var diskId = existingInstallation?.DiskId ?? _cfg.GetNewInstallationId();
         var binPath = Path.Combine(LauncherPaths.DirServerContent,
             diskId.ToString(CultureInfo.InvariantCulture) + ".zip");

--- a/SS14.Launcher/UriHelper.cs
+++ b/SS14.Launcher/UriHelper.cs
@@ -122,4 +122,24 @@ public static class UriHelper
     {
         return new Uri(GetServerApiAddress(serverAddress), "info");
     }
+
+    /// <summary>
+    ///     Gets the <c>/client.zip</c> HTTP address for a server address.
+    ///     This is not necessarily the actual client ZIP address.
+    /// </summary>
+    [Pure]
+    public static Uri GetServerSelfhostedClientZipAddress(string serverAddress)
+    {
+        return GetServerSelfhostedClientZipAddress(ParseSs14Uri(serverAddress));
+    }
+
+    /// <summary>
+    ///     Gets the <c>/client.zip</c> HTTP address for an ss14 uri.
+    ///     This is not necessarily the actual client ZIP address.
+    /// </summary>
+    [Pure]
+    public static Uri GetServerSelfhostedClientZipAddress(Uri serverAddress)
+    {
+        return new Uri(GetServerApiAddress(serverAddress), "client.zip");
+    }
 }


### PR DESCRIPTION
*This has been tested both in it's intended use-case and with production servers (checking to ensure a content download works) to ensure it breaks nothing.*

It is clear from both the code handling `ConnectAddress` inference and basic common sense in regards to server hosting ease-of-use that a server should not need to be configured with it's own address unless necessary.

However right now content client zips need to have a URL provided.

I have a RobustToolbox PR in progress ( https://github.com/space-wizards/RobustToolbox/pull/2225 ) that integrates a way for the status server to host the content client zip.
But that needs support from the launcher for the process to be as simple as possible, because the launcher requires a URL to download the zip from, and that goes all the way back to the whole "needs to be configured with it's own address" problem.

Thing is, the launcher already has all the information required, so simply canonizing a location for a status-server-hosted client file makes the most sense here.
