### PR TITLE
Add checkbox in MainWindowLogin to toggle logging

### DIFF
--- a/SS14.Launcher/ViewModels/MainWindowLoginViewModel.cs
+++ b/SS14.Launcher/ViewModels/MainWindowLoginViewModel.cs
@@ -65,4 +65,15 @@ public class MainWindowLoginViewModel : ViewModelBase
     {
         Screen = new RegisterNeedsConfirmationViewModel(this, _authApi, username, password, _loginMgr, _cfg);
     }
+
+    public bool LogLauncher
+    {
+        // This not a clean solution, replace it with something better.
+        get => _cfg.GetCVar(CVars.LogLauncher);
+        set
+        {
+            _cfg.SetCVar(CVars.LogLauncher, value);
+            _cfg.CommitConfig();
+        }
+    }
 }

--- a/SS14.Launcher/Views/MainWindowLogin.xaml
+++ b/SS14.Launcher/Views/MainWindowLogin.xaml
@@ -16,6 +16,8 @@
     <DockPanel Background="{DynamicResource ThemeStripeBackBrush}" DockPanel.Dock="Bottom"
                LastChildFill="False">
 
+      <CheckBox DockPanel.Dock="Left" VerticalAlignment="Center" Margin="4" IsChecked="{Binding LogLauncher}">Log Launcher</CheckBox>
+
       <TextBlock Text="{Binding Version}" DockPanel.Dock="Right" VerticalAlignment="Center" Margin="4"
                  Classes="SubText" />
     </DockPanel>


### PR DESCRIPTION
This is a temporary solution to solve #46. It's not good and should be replaced with a real solution at some point.

Note: Changing between the logged-in Options menu and the logged-out menu makes the logging checkboxes unrepresentative of what's actually set.