### PR TITLE
Change zstd library resolution to be more resilient

### DIFF
--- a/SS14.Launcher/Program.cs
+++ b/SS14.Launcher/Program.cs
@@ -73,6 +73,7 @@ internal static class Program
 
         VcRedistCheck.Check();
         LauncherPaths.CreateDirs();
+        ZStd.SetupResolver();
 
         var cfg = new DataManager();
         cfg.Load();

--- a/SS14.Launcher/Utility/ZStd.cs
+++ b/SS14.Launcher/Utility/ZStd.cs
@@ -47,9 +47,7 @@ public static class ZStd
                     // 0: RTLD_LOCAL
                     handle = _DLOpenLinux(v, 2 | 8 | 0);
                     if (handle != IntPtr.Zero)
-                    {
                         return handle;
-                    }
                 }
             }
 
@@ -59,9 +57,12 @@ public static class ZStd
 
             return IntPtr.Zero;
         });
-        try {
+        try
+        {
             CompressBound(0);
-        } catch (Exception ex) {
+        }
+        catch (Exception ex)
+        {
             // This is also called from Loader, so no Log
             Console.WriteLine(" -- ZStd.SetupResolver failed CompressBound(0) check!!! -- ");
             Console.WriteLine("This implies ZStd could not be loaded on your system.");

--- a/SS14.Loader/Program.cs
+++ b/SS14.Loader/Program.cs
@@ -8,6 +8,7 @@ using System.Runtime.InteropServices;
 using System.Runtime.Loader;
 using NSec.Cryptography;
 using Robust.LoaderApi;
+using SS14.Launcher.Utility;
 
 namespace SS14.Loader;
 
@@ -138,6 +139,8 @@ internal class Program
             Console.WriteLine("Usage: SS14.Loader <robustPath> <signature> <public key> [engineArg [engineArg...]]");
             return 1;
         }
+
+        ZStd.SetupResolver();
 
         var robustPath = args[0];
         var sig = Convert.FromHexString(args[1]);


### PR DESCRIPTION
Should remove one of the workarounds needed on Linux.