### PR TITLE
Fix zstd finding on Ubuntu 22.04 maybe

### DIFF
--- a/SS14.Launcher/Utility/Libc.cs
+++ b/SS14.Launcher/Utility/Libc.cs
@@ -14,6 +14,6 @@ internal static class Libc
     public const int RTLD_LOCAL = 0;
     public const int RTLD_NODELETE = 0x01000;
 
-    [DllImport("libdl")]
+    [DllImport("libdl.so.2")]
     public static extern IntPtr dlopen([MarshalAs(UnmanagedType.LPUTF8Str)] string name, int flags);
 }

--- a/SS14.Launcher/Utility/ZStd.cs
+++ b/SS14.Launcher/Utility/ZStd.cs
@@ -33,25 +33,33 @@ public static class ZStd
     {
         if (name == "zstd" && OperatingSystem.IsLinux())
         {
-            var paths = (string)AppContext.GetData("NATIVE_DLL_SEARCH_DIRECTORIES")!;
-            foreach (var p in paths.Split(':', StringSplitOptions.RemoveEmptyEntries))
+            try
             {
-                var tryPath = Path.Join(p, "zstd.so");
-                // Console.WriteLine($"TRYING: {tryPath}");
-                var result = dlopen(tryPath, RTLD_LOCAL | RTLD_DEEPBIND | RTLD_LAZY);
-                // Console.WriteLine(result);
-                if (result != IntPtr.Zero)
+                var paths = (string)AppContext.GetData("NATIVE_DLL_SEARCH_DIRECTORIES")!;
+                foreach (var p in paths.Split(':', StringSplitOptions.RemoveEmptyEntries))
                 {
-                    // Console.WriteLine($"FOUND: {tryPath}");
-                    return result;
+                    var tryPath = Path.Join(p, "zstd.so");
+                    // Console.WriteLine($"TRYING: {tryPath}");
+                    var result = dlopen(tryPath, RTLD_LOCAL | RTLD_DEEPBIND | RTLD_LAZY);
+                    // Console.WriteLine(result);
+                    if (result != IntPtr.Zero)
+                    {
+                        // Console.WriteLine($"FOUND: {tryPath}");
+                        return result;
+                    }
                 }
+            }
+            catch (Exception ex)
+            {
+                // Catch and at least provide some way of retrieving this.
+                Console.WriteLine($"Exception during ZStd libdl search: {ex}");
             }
 
             // Try some extra paths too worst case.
-            if (NativeLibrary.TryLoad("libzstd.so", out var handle))
+            if (NativeLibrary.TryLoad("libzstd.so.1", out var handle))
                 return handle;
 
-            if (NativeLibrary.TryLoad("libzstd.so.1", out handle))
+            if (NativeLibrary.TryLoad("libzstd.so", out handle))
                 return handle;
         }
 


### PR DESCRIPTION
+ Adds a try/catch so that fallbacks will still be attempted if, say, `libdl` can't be found
+ Fixes used `libdl` library name
+ Tries `libzstd.so.1` (the actual wanted version) before `libzstd.so` (a potentially future or past version)