### PR TITLE
Button to raise favorite servers in the home tab

### DIFF
--- a/SS14.Launcher/Models/Data/DataManager.cs
+++ b/SS14.Launcher/Models/Data/DataManager.cs
@@ -143,6 +143,19 @@ public sealed class DataManager : ReactiveObject
         _favoriteServers.Remove(server);
     }
 
+    public void RaiseFavoriteServer(FavoriteServer server)
+    {
+        var found = _favoriteServers.Lookup(server.Address);
+        if (!found.HasValue)
+        {
+            throw new ArgumentException("Cannot raise a favorite server that isn't a favorite in the first place.");
+        }
+        // Note the long->double conversion. This conversion will lose precision in around half a million years.
+        // However, it beats betting something won't go wrong with using long in JSON.
+        found.Value.RaiseTime = ((double) DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()) / 1000;
+        _favoriteServers.AddOrUpdate(found.Value);
+    }
+
     public void AddEngineInstallation(InstalledEngineVersion version)
     {
         _engineInstallations.AddOrUpdate(version);

--- a/SS14.Launcher/Models/Data/FavoriteServer.cs
+++ b/SS14.Launcher/Models/Data/FavoriteServer.cs
@@ -10,6 +10,7 @@ namespace SS14.Launcher.Models.Data;
 public sealed class FavoriteServer : ReactiveObject
 {
     private string? _name;
+    private double _raiseTime;
 
     // For serialization.
     public FavoriteServer()
@@ -32,4 +33,16 @@ public sealed class FavoriteServer : ReactiveObject
 
     [JsonProperty(PropertyName = "address")]
     public string Address { get; private set; } // Need private set for JSON.NET to work.
+
+    /// <summary>
+    /// Used to infer an exact ordering for servers in a simple, compatible manner.
+    /// Format is a Unix timestamp in seconds as this provides simple, fast comparison - this isn't meant to really be used as a date.
+    /// Defaults to 0, this is fine.
+    /// </summary>
+    [JsonProperty(PropertyName = "raiseTime")]
+    public double RaiseTime
+    {
+        get => _raiseTime;
+        set => this.RaiseAndSetIfChanged(ref _raiseTime, value);
+    }
 }

--- a/SS14.Launcher/Models/Data/FavoriteServer.cs
+++ b/SS14.Launcher/Models/Data/FavoriteServer.cs
@@ -10,7 +10,7 @@ namespace SS14.Launcher.Models.Data;
 public sealed class FavoriteServer : ReactiveObject
 {
     private string? _name;
-    private double _raiseTime;
+    private DateTimeOffset _raiseTime;
 
     // For serialization.
     public FavoriteServer()
@@ -22,6 +22,13 @@ public sealed class FavoriteServer : ReactiveObject
     {
         Name = name;
         Address = address;
+    }
+
+    public FavoriteServer(string? name, string address, DateTimeOffset raiseTime)
+    {
+        Name = name;
+        Address = address;
+        RaiseTime = raiseTime;
     }
 
     [JsonProperty(PropertyName = "name")]
@@ -36,11 +43,10 @@ public sealed class FavoriteServer : ReactiveObject
 
     /// <summary>
     /// Used to infer an exact ordering for servers in a simple, compatible manner.
-    /// Format is a Unix timestamp in seconds as this provides simple, fast comparison - this isn't meant to really be used as a date.
     /// Defaults to 0, this is fine.
+    /// This isn't saved in JSON because the launcher apparently doesn't use JSON for these anymore.
     /// </summary>
-    [JsonProperty(PropertyName = "raiseTime")]
-    public double RaiseTime
+    public DateTimeOffset RaiseTime
     {
         get => _raiseTime;
         set => this.RaiseAndSetIfChanged(ref _raiseTime, value);

--- a/SS14.Launcher/Models/Data/Migrations/Script0004_RaiseTime.sql
+++ b/SS14.Launcher/Models/Data/Migrations/Script0004_RaiseTime.sql
@@ -1,0 +1,3 @@
+ALTER TABLE FavoriteServer
+ADD RaiseTime DATETIME;
+

--- a/SS14.Launcher/ViewModels/MainWindowTabs/HomePageViewModel.cs
+++ b/SS14.Launcher/ViewModels/MainWindowTabs/HomePageViewModel.cs
@@ -28,7 +28,7 @@ public class HomePageViewModel : MainWindowTabViewModel
 
         _cfg.FavoriteServers
             .Connect()
-            .Select(x => new ServerEntryViewModel(MainWindowViewModel, _statusCache.GetStatusFor(x.Address), x))
+            .Select(x => new ServerEntryViewModel(MainWindowViewModel, _statusCache.GetStatusFor(x.Address), x) { ViewedInFavoritesPane = true })
             .OnItemAdded(a =>
             {
                 if (IsSelected)
@@ -36,7 +36,14 @@ public class HomePageViewModel : MainWindowTabViewModel
                     _statusCache.InitialUpdateStatus(a.CacheData);
                 }
             })
-            .Sort(Comparer<ServerEntryViewModel>.Create((a, b) => string.Compare(a.Name, b.Name, StringComparison.CurrentCultureIgnoreCase)))
+            .Sort(Comparer<ServerEntryViewModel>.Create((a, b) => {
+                var dc = a.Favorite!.RaiseTime.CompareTo(b.Favorite!.RaiseTime);
+                if (dc != 0)
+                {
+                    return -dc;
+                }
+                return string.Compare(a.Name, b.Name, StringComparison.CurrentCultureIgnoreCase);
+            }))
             .Bind(out var favorites)
             .Subscribe(_ => FavoritesEmpty = favorites.Count == 0);
 

--- a/SS14.Launcher/ViewModels/MainWindowTabs/ServerEntryViewModel.cs
+++ b/SS14.Launcher/ViewModels/MainWindowTabs/ServerEntryViewModel.cs
@@ -61,6 +61,8 @@ public sealed class ServerEntryViewModel : ObservableRecipient, IRecipient<Favor
     public string FavoriteButtonText => IsFavorite ? "Remove Favorite" : "Add Favorite";
     private bool IsFavorite => _cfg.FavoriteServers.Lookup(Address).HasValue;
 
+    public bool ViewedInFavoritesPane { get; set; }
+
     public string ServerStatusString => _cacheData.Status switch
     {
         ServerStatusCode.Offline => "Unable to connect",
@@ -96,6 +98,17 @@ public sealed class ServerEntryViewModel : ObservableRecipient, IRecipient<Favor
         {
             var fav = new FavoriteServer(_cacheData.Name ?? FallbackName, Address);
             _cfg.AddFavoriteServer(fav);
+        }
+
+        _cfg.CommitConfig();
+    }
+
+    public void FavoriteRaiseButtonPressed()
+    {
+        if (IsFavorite)
+        {
+            // Usual business, raise priority
+            _cfg.RaiseFavoriteServer(_cfg.FavoriteServers.Lookup(Address).Value);
         }
 
         _cfg.CommitConfig();

--- a/SS14.Launcher/Views/MainWindowTabs/ServerEntryView.xaml
+++ b/SS14.Launcher/Views/MainWindowTabs/ServerEntryView.xaml
@@ -23,8 +23,22 @@
           <TextBlock VerticalAlignment="Center" Text="{Binding Name}" />
         </DockPanel>
       </Expander.Header>
-      <DockPanel>
-        <Button DockPanel.Dock="Bottom" HorizontalAlignment="Right" Margin="4"
+      <DockPanel Margin="4">
+        <!-- Raise to top button. -->
+        <Button DockPanel.Dock="Right" HorizontalAlignment="Right"
+                IsVisible="{Binding ViewedInFavoritesPane}" Classes="OpenLeft"
+                Content="Raise to top"
+                Command="{Binding FavoriteRaiseButtonPressed}" />
+        <!--
+            Two versions of the favorite/unfavorite button based on if we're in the favorites pane.
+            This is so that OpenRight is applied properly.
+        -->
+        <Button DockPanel.Dock="Right" HorizontalAlignment="Right"
+                IsVisible="{Binding ViewedInFavoritesPane}" Classes="OpenRight"
+                Content="{Binding FavoriteButtonText}"
+                Command="{Binding FavoriteButtonPressed}" />
+        <Button DockPanel.Dock="Right" HorizontalAlignment="Right"
+                IsVisible="{Binding !ViewedInFavoritesPane}"
                 Content="{Binding FavoriteButtonText}"
                 Command="{Binding FavoriteButtonPressed}" />
       </DockPanel>


### PR DESCRIPTION
Useful for organization.
About the "raise to top" workflow: I'm not sure of a better way to handle this sort of re-ordering given that the favorite servers are no longer strictly just an array.
Updating all of the favorite servers at once *could* do it but I don't think that'd be what would be wanted.
Maybe some sort of floating-point binary tree could work, but I think the fact I'm suggesting that gives an idea of the problem here.
![image](https://user-images.githubusercontent.com/22304167/164989274-24de320b-7f89-4fea-88e9-b72125011f65.png)

(Note that the "Raise to top" button does not appear in the main servers list for hopefully obvious reasons.)