### PR TITLE
Fix launcher version name

### DIFF
--- a/SS14.Launcher/LauncherVersion.cs
+++ b/SS14.Launcher/LauncherVersion.cs
@@ -4,6 +4,6 @@ namespace SS14.Launcher;
 
 public static class LauncherVersion
 {
-    public const string Name = "SS14.Laucher";
+    public const string Name = "SS14.Launcher";
     public static Version? Version => typeof(LauncherVersion).Assembly.GetName().Version;
 }


### PR DESCRIPTION
I have no idea if this has any repercussions but I noticed that the `UserAgent` was wrong when doing some funny business