### PR TITLE
Read and display max players from server status

### DIFF
--- a/SS14.Launcher/Models/ServerStatus/ServerStatusCache.Data.cs
+++ b/SS14.Launcher/Models/ServerStatus/ServerStatusCache.Data.cs
@@ -8,6 +8,7 @@ public sealed class ServerStatusData : ObservableObject, IServerStatusData
     private string? _name;
     private TimeSpan? _ping;
     private int _playerCount;
+    private int _softMaxPlayerCount;
     private ServerStatusCode _status = ServerStatusCode.FetchingStatus;
 
     public ServerStatusData(string address)
@@ -41,5 +42,11 @@ public sealed class ServerStatusData : ObservableObject, IServerStatusData
     {
         get => _playerCount;
         set => SetProperty(ref _playerCount, value);
+    }
+
+    public int SoftMaxPlayerCount
+    {
+        get => _softMaxPlayerCount;
+        set => SetProperty(ref _softMaxPlayerCount, value);
     }
 }

--- a/SS14.Launcher/Models/ServerStatus/ServerStatusCache.cs
+++ b/SS14.Launcher/Models/ServerStatus/ServerStatusCache.cs
@@ -113,6 +113,7 @@ public sealed class ServerStatusCache
             data.Status = ServerStatusCode.Online;
             data.Name = status.Name;
             data.PlayerCount = status.PlayerCount;
+            data.SoftMaxPlayerCount = status.SoftMaxPlayerCount;
         }
         catch (OperationCanceledException)
         {
@@ -153,6 +154,9 @@ public sealed class ServerStatusCache
 
         [JsonProperty(PropertyName = "players")]
         public int PlayerCount { get; set; }
+
+        [JsonProperty(PropertyName = "soft_max_players")]
+        public int SoftMaxPlayerCount { get; set; }
     }
 
     private sealed class CacheReg

--- a/SS14.Launcher/ViewModels/MainWindowTabs/ServerEntryViewModel.cs
+++ b/SS14.Launcher/ViewModels/MainWindowTabs/ServerEntryViewModel.cs
@@ -73,13 +73,13 @@ public sealed class ServerEntryViewModel : ObservableRecipient, IRecipient<Favor
     {
         get
         {
-            switch(_cacheData.Status)
+            switch (_cacheData.Status)
             {
                 case ServerStatusCode.Offline:
                     return "Unable to connect";
                 case ServerStatusCode.Online:
                     // Give a ratio for servers with a defined player count, or just a current number for those without.
-                    if(_cacheData.SoftMaxPlayerCount > 0)
+                    if (_cacheData.SoftMaxPlayerCount > 0)
                     {
                         return $"Online: {_cacheData.PlayerCount} / {_cacheData.SoftMaxPlayerCount} players";
                     }

--- a/SS14.Launcher/ViewModels/MainWindowTabs/ServerEntryViewModel.cs
+++ b/SS14.Launcher/ViewModels/MainWindowTabs/ServerEntryViewModel.cs
@@ -72,9 +72,7 @@ public sealed class ServerEntryViewModel : ObservableRecipient, IRecipient<Favor
     public string ServerStatusString => _cacheData.Status switch
     {
         ServerStatusCode.Offline => "Unable to connect",
-        ServerStatusCode.Online => _cacheData.PlayerCount == 1
-            ? $"Online: {_cacheData.PlayerCount} player"
-            : $"Online: {_cacheData.PlayerCount} players",
+        ServerStatusCode.Online => $"Online: {_cacheData.PlayerCount} / {_cacheData.SoftMaxPlayerCount} players",
         ServerStatusCode.FetchingStatus => "Fetching status...",
         _ => throw new NotSupportedException()
     };

--- a/SS14.Launcher/ViewModels/MainWindowTabs/ServerEntryViewModel.cs
+++ b/SS14.Launcher/ViewModels/MainWindowTabs/ServerEntryViewModel.cs
@@ -69,13 +69,31 @@ public sealed class ServerEntryViewModel : ObservableRecipient, IRecipient<Favor
 
     public bool ViewedInFavoritesPane { get; set; }
 
-    public string ServerStatusString => _cacheData.Status switch
+    public string ServerStatusString
     {
-        ServerStatusCode.Offline => "Unable to connect",
-        ServerStatusCode.Online => $"Online: {_cacheData.PlayerCount} / {_cacheData.SoftMaxPlayerCount} players",
-        ServerStatusCode.FetchingStatus => "Fetching status...",
-        _ => throw new NotSupportedException()
-    };
+        get
+        {
+            switch(_cacheData.Status)
+            {
+                case ServerStatusCode.Offline:
+                    return "Unable to connect";
+                case ServerStatusCode.Online:
+                    // Give a ratio for servers with a defined player count, or just a current number for those without.
+                    if(_cacheData.SoftMaxPlayerCount > 0)
+                    {
+                        return $"Online: {_cacheData.PlayerCount} / {_cacheData.SoftMaxPlayerCount} players";
+                    }
+                    else
+                    {
+                        return _cacheData.PlayerCount == 1 ? $"Online: {_cacheData.PlayerCount} player" : $"Online: {_cacheData.PlayerCount} players";
+                    }
+                case ServerStatusCode.FetchingStatus:
+                    return "Fetching status...";
+                default:
+                    throw new NotSupportedException();
+            }
+        }
+    }
 
     public bool IsOnline => _cacheData.Status == ServerStatusCode.Online;
 


### PR DESCRIPTION
Resolves #69 

Changes:
- New variables and piping for SoftMaxPlayers in a few classes
- Loads the "soft_max_players" field from each server's status page, into the new class vars
- Updates output from "[current] players" display to " [current] / [max] players" in Server List

Also requires Content.Server changes adding new field to status responses. PR link: https://github.com/space-wizards/space-station-14/pull/9365

Screenshot of updated launcher (using some rand values for max since Server changes are not live):
![PlayerRatios](https://user-images.githubusercontent.com/69610864/177020452-6c559e5e-9b7b-480d-a973-93f110202460.PNG)
