### PR TITLE
Avoid bug where favorites window wouldn't show max player count on first display

### DIFF
--- a/SS14.Launcher/Models/ServerStatus/IServerStatusData.cs
+++ b/SS14.Launcher/Models/ServerStatus/IServerStatusData.cs
@@ -23,4 +23,6 @@ public interface IServerStatusData : INotifyPropertyChanged
     ServerStatusInfoCode StatusInfo { get; set; }
 
     int PlayerCount { get; set; }
+
+    int SoftMaxPlayerCount { get; set; }
 }

--- a/SS14.Launcher/Models/ServerStatus/ServerStatusCache.cs
+++ b/SS14.Launcher/Models/ServerStatus/ServerStatusCache.cs
@@ -110,8 +110,8 @@ public sealed class ServerStatusCache
 
             data.Status = ServerStatusCode.Online;
             data.Name = status.Name;
-            data.PlayerCount = status.PlayerCount;
             data.SoftMaxPlayerCount = status.SoftMaxPlayerCount;
+            data.PlayerCount = status.PlayerCount;
         }
         catch (OperationCanceledException)
         {

--- a/SS14.Launcher/Models/ServerStatus/ServerStatusCache.cs
+++ b/SS14.Launcher/Models/ServerStatus/ServerStatusCache.cs
@@ -110,8 +110,8 @@ public sealed class ServerStatusCache
 
             data.Status = ServerStatusCode.Online;
             data.Name = status.Name;
-            data.SoftMaxPlayerCount = status.SoftMaxPlayerCount;
             data.PlayerCount = status.PlayerCount;
+            data.SoftMaxPlayerCount = status.SoftMaxPlayerCount;
         }
         catch (OperationCanceledException)
         {

--- a/SS14.Launcher/ViewModels/MainWindowTabs/ServerEntryViewModel.cs
+++ b/SS14.Launcher/ViewModels/MainWindowTabs/ServerEntryViewModel.cs
@@ -29,6 +29,7 @@ public sealed class ServerEntryViewModel : ObservableRecipient, IRecipient<Favor
             switch (args.PropertyName)
             {
                 case nameof(IServerStatusData.PlayerCount):
+                case nameof(IServerStatusData.SoftMaxPlayerCount):
                     OnPropertyChanged(nameof(ServerStatusString));
                     break;
 


### PR DESCRIPTION
ServerEntryViewModel used a callback to listen for changes to the server's PlayerCount property. When populating server info, the PlayerCount was set before the SoftMaxPlayerCount, so when generating the text representation of the server info, it didn't see the max player count. Initialize SoftMaxPlayerCount before PlayerCount to get the expected behaviour the first time the favorites window is rendered.