### PR TITLE
Server list makeover

### DIFF
--- a/SS14.Launcher/Theme/Theme.xaml
+++ b/SS14.Launcher/Theme/Theme.xaml
@@ -58,4 +58,9 @@
   <Style Selector="Button.BigButton > TextBlock">
     <Setter Property="FontSize" Value="20" />
   </Style>
+
+  <Style Selector="Separator">
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="BorderBrush" Value="{DynamicResource ThemeListSeparatorBrush}" />
+  </Style>
 </Styles>

--- a/SS14.Launcher/Theme/ThemeResources.xaml
+++ b/SS14.Launcher/Theme/ThemeResources.xaml
@@ -16,6 +16,9 @@
     <Color x:Key="ThemeTabItemSelectedColor">#CC3E6C45</Color>
     <Color x:Key="ThemeTabItemHoveredColor">#CC575B7F</Color>
 
+    <Color x:Key="ThemeListSeparatorColor">#AA575B7F</Color>
+    <Color x:Key="ThemeListSeparatorColorTransparent">#00575B7F</Color>
+
     <SolidColorBrush x:Key="ThemeBackgroundBrush" Color="{StaticResource ThemeBackgroundColor}" />
     <SolidColorBrush x:Key="ThemeForegroundBrush" Color="{StaticResource ThemeForegroundColor}" />
 
@@ -29,6 +32,11 @@
 
     <SolidColorBrush x:Key="ThemeTabItemSelectedBrush" Color="{StaticResource ThemeTabItemSelectedColor}" />
     <SolidColorBrush x:Key="ThemeTabItemHoveredBrush" Color="{StaticResource ThemeTabItemHoveredColor}" />
+
+    <RadialGradientBrush x:Key="ThemeListSeparatorBrush" Radius="12">
+      <GradientStop Offset="0" Color="{StaticResource ThemeListSeparatorColor}"/>
+      <GradientStop Offset="1" Color="{StaticResource ThemeListSeparatorColorTransparent}"/>
+    </RadialGradientBrush>
 
     <sys:Double x:Key="FontSizeNormal">15</sys:Double>
 

--- a/SS14.Launcher/ViewModels/MainWindowTabs/ServerEntryViewModel.cs
+++ b/SS14.Launcher/ViewModels/MainWindowTabs/ServerEntryViewModel.cs
@@ -94,19 +94,19 @@ public sealed class ServerEntryViewModel : ObservableRecipient, IRecipient<Favor
             switch (_cacheData.Status)
             {
                 case ServerStatusCode.Offline:
-                    return "Unable to connect";
+                    return "OFFLINE";
                 case ServerStatusCode.Online:
                     // Give a ratio for servers with a defined player count, or just a current number for those without.
                     if (_cacheData.SoftMaxPlayerCount > 0)
                     {
-                        return $"Online: {_cacheData.PlayerCount} / {_cacheData.SoftMaxPlayerCount} players";
+                        return $"{_cacheData.PlayerCount} / {_cacheData.SoftMaxPlayerCount}";
                     }
                     else
                     {
-                        return _cacheData.PlayerCount == 1 ? $"Online: {_cacheData.PlayerCount} player" : $"Online: {_cacheData.PlayerCount} players";
+                        return $"{_cacheData.PlayerCount} / ∞";
                     }
                 case ServerStatusCode.FetchingStatus:
-                    return "Fetching status...";
+                    return "Fetching...";
                 default:
                     throw new NotSupportedException();
             }

--- a/SS14.Launcher/Views/MainWindowTabs/ServerEntryView.xaml
+++ b/SS14.Launcher/Views/MainWindowTabs/ServerEntryView.xaml
@@ -18,9 +18,10 @@
           <Button IsEnabled="{Binding IsOnline}" DockPanel.Dock="Right" Content="Connect"
                   Command="{Binding ConnectPressed}" />
           <TextBlock DockPanel.Dock="Right" VerticalAlignment="Center"
-                     TextAlignment="Left" Text="{Binding ServerStatusString}"
-                     MinWidth="150"
+                     TextAlignment="Center" Text="{Binding ServerStatusString}"
+                     MinWidth="80"
                      Margin="10, 0" />
+          <Separator DockPanel.Dock="Right" />
           <!-- TODO: Enable text trimming here when Avalonia 0.10 is out of preview and we switch to it. -->
           <TextBlock VerticalAlignment="Center" Text="{Binding Name}" />
         </DockPanel>

--- a/SS14.Launcher/Views/MainWindowTabs/ServerListTabView.xaml
+++ b/SS14.Launcher/Views/MainWindowTabs/ServerListTabView.xaml
@@ -11,13 +11,20 @@
   </Design.DataContext>
 
   <DockPanel LastChildFill="True">
-    <DockPanel DockPanel.Dock="Top" LastChildFill="False" Margin="4, 0, 4, 2">
-      <TextBlock DockPanel.Dock="Left" Text="Servers:" Classes="NanoHeadingMedium" />
-      <Button DockPanel.Dock="Right" Content="Refresh" Command="{Binding RefreshPressed}" />
+    <DockPanel DockPanel.Dock="Top" Margin="4, 0, 4, 2">
+      <!--TODO: These measurements are just golfed based on approximations of where the sections *probably* are, and assumes a scroll bar is present. This might prove a bit wonky with localization and excessive screen sizes. It'd be ideal if this header section could dynamically adapt to the section sizes in the server list.-->
+      <Separator DockPanel.Dock="Right" Margin="0 0 101 0"/>
+      <TextBlock DockPanel.Dock="Right" Text="Players" Classes="SubText" TextAlignment="Center" MinWidth="80" Margin="10 0"/>
+      <Separator DockPanel.Dock="Right" />
+      <TextBlock DockPanel.Dock="Right" Text="Server Name" Classes="SubText"/>
     </DockPanel>
 
-    <TextBox DockPanel.Dock="Bottom" Text="{Binding SearchString, Mode=TwoWay}" Watermark="Search For Servers..."
-             UseFloatingWatermark="False" />
+    <DockPanel DockPanel.Dock="Bottom" Margin="4 4 4 0">
+      <Button DockPanel.Dock="Right" Content="Refresh" Command="{Binding RefreshPressed}" />
+      <TextBox DockPanel.Dock="Right" Text="{Binding SearchString, Mode=TwoWay}" Watermark="Search For Servers..."
+               UseFloatingWatermark="False"
+               Margin="0 0 8 0" />
+    </DockPanel>
 
     <Panel DockPanel.Dock="Bottom" Classes="ScrollViewerSep" />
     <Panel DockPanel.Dock="Top" Classes="ScrollViewerSep" />


### PR DESCRIPTION
During our time lurking, we've noticed that the launcher's UI is a common UI-related grumble. And when you look at it yourself, it's easy to see why! There's a lot of visual noise, blank space, and more. The launcher's server list is borderline unusable if you don't resize it above it's default resolution, as there's simply way too much visual clutter.

So this PR seeks to improve that through a basic UI quality pass.

Here's what the server list looks like before this PR:
![image](https://user-images.githubusercontent.com/6356337/211245344-24dc2512-4780-4203-a4f1-6f70fe8a9138.png)


And here's what the server list looks like after this PR:
![image](https://user-images.githubusercontent.com/6356337/211245403-b18b4716-c568-4fa4-983e-6957f232aba8.png)


Most of these changes are fairly self-explanatory, and were made largely through a mix of intuition and lurking chat.
The refresh button has been moved from the header to the footer, so that the server list's main controls are close to each other (with the side effect of making the search bug's workaround more likely to be intuited).

The header (the `Servers:` text is visually noisy and somewhat redundant due to the current tab already being indicated at the bottom of the launcher) has been converted into labels for the server list below (In the future, it might be worth converting these into buttons for sorting), such that the list's info remains clear at a glance.

Info is now divided by separators, as well, to ensure that long server names don't cause visual confusion with the playercount. A gradient is used here largely to avoid making the separators look jarring when a server's info is expanded.

The playercount is probably the biggest change here, with the `Online:` and `... Players` being axed completely due to the sheer amount of visual noise and clutter they cause.


Also, a quick rant. We wanted to fix the current search bug where searches only apply when you refresh the server list (that was our original intent when first poking at the launcher), but we ended up spending 9 hours straight sifting through AvaloniaUI and ReactiveUI's documentation to absolutely no avail. Even after taking a break for dinner, slapping together everything that's now featured in this PR, and spending a further 4 hours trying to fix the search bug, we still cannot figure it out. By all means, BY ALL MEANS, the current search implementation should already be filtering the server list in real-time as you type. But for whatever mystical reason, it simply bypasses the setter function entirely, regardless of what you do. The documentation is fairly vague on what the frameworks' developers intend for you to do, and going so far as to follow the documentation *to the letter*, even copying and pasting directly from the documentation, yields compiling errors or does nothing at all. Attempting to search for the issue of `TextBox` bypassing setter functions yields no useful results, as all alternatives given either result in compiling errors or does literally nothing. This is beyond our skill level. We've thrown the towel in. We now like RT's UI framework significantly more than we did prior because good lord the alternative is a *mess*.


But! On the bright side of things, at least that fiasco has indirectly lead to this PR. If we can't make the UI function in the way that, by every imaginable means, should already be working, then by god we're at least gonna make the UI look pretty.