### PR TITLE
Remove suggestions from launcher

### DIFF
--- a/SS14.Launcher/ViewModels/MainWindowTabs/HomePageViewModel.cs
+++ b/SS14.Launcher/ViewModels/MainWindowTabs/HomePageViewModel.cs
@@ -51,19 +51,15 @@ public class HomePageViewModel : MainWindowTabViewModel
             .Subscribe(_ =>
             {
                 FavoritesEmpty = favorites.Count == 0;
-                ShowSuggestions = favorites.Count <= 3;
             });
 
         Favorites = favorites;
-
-        _serverListCache.AllServers.CollectionChanged += (_, _) => UpdateSuggestions();
     }
 
     public ReadOnlyObservableCollection<ServerEntryViewModel> Favorites { get; }
     public ObservableCollection<ServerEntryViewModel> Suggestions { get; } = new();
 
     [Reactive] public bool FavoritesEmpty { get; private set; } = true;
-    [Reactive] public bool ShowSuggestions { get; private set; } = true;
 
     public override string Name => "Home";
     public Control? Control { get; set; }
@@ -124,29 +120,5 @@ public class HomePageViewModel : MainWindowTabViewModel
             _statusCache.InitialUpdateStatus(favorite.CacheData);
         }
         _serverListCache.RequestInitialUpdate();
-    }
-
-    public void UpdateSuggestions()
-    {
-        // Determine suggestions.
-        // Note that we don't bother updating this when favorites change.
-        Suggestions.Clear();
-        var candidates = _serverListCache.AllServers.
-            Where(x => x.Data.PlayerCount != 0). // Servers with players
-            Where(x => !(_cfg.FavoriteServers.Lookup(x.Data.Address).HasValue)). // That are not already favorited
-            ToList();
-        var rng = new Random();
-        // Pick candidates.
-        for (var i = 0; i < 2; i++)
-        {
-            if (candidates.Count == 0)
-            {
-                break;
-            }
-            var p = rng.Next(candidates.Count);
-            var v = candidates[p];
-            candidates.RemoveAt(p);
-            Suggestions.Add(new ServerEntryViewModel(MainWindowViewModel, v));
-        }
     }
 }

--- a/SS14.Launcher/Views/MainWindowTabs/HomePageView.xaml
+++ b/SS14.Launcher/Views/MainWindowTabs/HomePageView.xaml
@@ -33,15 +33,9 @@
       <ScrollViewer MinHeight="150" HorizontalScrollBarVisibility="Disabled">
         <Panel>
           <DockPanel IsVisible="{Binding !FavoritesEmpty}" LastChildFill="True">
-            <StackPanel DockPanel.Dock="Bottom" IsVisible="{Binding ShowSuggestions}"
-                        Orientation="Vertical" VerticalAlignment="Center">
-              <TextBlock Text="There are other servers you can join..." HorizontalAlignment="Center"
-                         Margin="0 10 0 10" />
-              <ItemsControl DockPanel.Dock="Top"
-                            Items="{Binding Suggestions}"
-                            Classes="ServerList" />
-              <Button Content="Go to the servers tab" Command="{Binding MainWindowViewModel.SelectTabServers}"
-                      HorizontalAlignment="Center" />
+            <StackPanel DockPanel.Dock="Bottom" IsVisible="True">
+            <Button Content="Go to the servers tab" Command="{Binding MainWindowViewModel.SelectTabServers}"
+                    HorizontalAlignment="Center" />
             </StackPanel>
             <ItemsControl Items="{Binding Favorites}"
                           Classes="ServerList" />


### PR DESCRIPTION
The suggestions window was fine earlier on in SS14 history to bring attention to other servers. Now, with the thriving SS14 ecosystem, it is a bit superfluous and also it's like weirdly small? idk I think it had its time in the sun.

![CleanShot 2023-01-21 at 09 56 16](https://user-images.githubusercontent.com/1261392/213880478-d4bcc31d-8f77-47f7-9500-f2f760b3f949.png)
