### PR TITLE
Change language selector to drop down menu.

### DIFF
--- a/SS14.Launcher/Views/MainWindowTabs/ServerListFiltersView.xaml
+++ b/SS14.Launcher/Views/MainWindowTabs/ServerListFiltersView.xaml
@@ -2,6 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:views="clr-namespace:SS14.Launcher.Views"
              xmlns:mainWindowTabs="clr-namespace:SS14.Launcher.ViewModels.MainWindowTabs"
              xmlns:mainWindowTabs1="clr-namespace:SS14.Launcher.Views.MainWindowTabs"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
@@ -24,10 +25,22 @@
 
     <ScrollViewer>
       <StackPanel Orientation="Vertical">
-        <DockPanel Classes="ServerFilterGroup">
-          <TextBlock MinWidth="150" DockPanel.Dock="Left" Classes="SubText" Text="Language" />
-          <ItemsControl Items="{Binding FiltersLanguage}"
-                        ItemsPanel="{StaticResource PanelTemplate}" ItemTemplate="{StaticResource FilterTemplate}"/>
+        <DockPanel Classes="ServerFilterGroup" HorizontalAlignment="Left">
+          <views:DropDown HeaderContent="Language" Width="300">
+            <Panel>
+              <views:AngleBox Fill="{DynamicResource ThemeBackgroundBrush}" SideStyle="OpenRight" />
+              <StackPanel Orientation="Vertical">
+                <ItemsControl Items="{Binding FiltersLanguage}"
+                              ItemsPanel="{StaticResource PanelTemplate}" ItemTemplate="{StaticResource FilterTemplate}">
+                  <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                      <WrapPanel Orientation="Vertical" />
+                    </ItemsPanelTemplate>
+                  </ItemsControl.ItemsPanel>
+                </ItemsControl>
+              </StackPanel>
+            </Panel>
+          </views:DropDown>
         </DockPanel>
         <DockPanel Classes="ServerFilterGroup">
           <TextBlock MinWidth="150" DockPanel.Dock="Left" Classes="SubText" Text="Region" />


### PR DESCRIPTION
It would be nice to have more than 3 languages in the server filter menu in the future. Because of this, I think it would be better to have a language selection menu in the form of a drop-down menu with checkboxes, rather than just a list of them.

This is my first commit for this project, as well as for the C# project in general. I do not know if there are any mistakes, how it should be designed, etc. (I also think it is ugly). It just works on my machine (pic attached) and I believe it should work.

![image](https://github.com/space-wizards/SS14.Launcher/assets/38111072/53fab063-f327-4c8e-b7d1-7121c99c9676)
