### PR TITLE
Only display news posts in news tab

### DIFF
--- a/SS14.Launcher/ViewModels/MainWindowTabs/NewsTabViewModel.cs
+++ b/SS14.Launcher/ViewModels/MainWindowTabs/NewsTabViewModel.cs
@@ -8,7 +8,7 @@ namespace SS14.Launcher.ViewModels.MainWindowTabs;
 
 public class NewsTabViewModel : MainWindowTabViewModel
 {
-    private const string FeedUrl = "https://spacestation14.io/index.xml";
+    private const string FeedUrl = "https://spacestation14.io/post/index.xml";
 
     private bool _startedPullingNews;
     private bool _newsPulled;


### PR DESCRIPTION
Before, pages like Downloads and the FAQ were also displayed in the News tab. With this change the launcher will have the same posts as displayed in https://spacestation14.io/post/.