### PR TITLE
Remove the x from setx

### DIFF
--- a/SS14.Launcher.Bootstrap/console.bat
+++ b/SS14.Launcher.Bootstrap/console.bat
@@ -1,4 +1,4 @@
-SETX DOTNET_ROOT "%CD%\dotnet"
+SET DOTNET_ROOT "%CD%\dotnet"
 
 dotnet\dotnet.exe bin\SS14.Launcher.dll
 


### PR DESCRIPTION
`setx` sets the systems environmental values permanently which is probably a real big nono

accidently webedited to master branch i will delete this repo anyway after so is fine