### PR TITLE
Unfocus connect button on press

### DIFF
--- a/SS14.Launcher/ViewModels/MainWindowTabs/ServerEntryViewModel.cs
+++ b/SS14.Launcher/ViewModels/MainWindowTabs/ServerEntryViewModel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel;
+using Avalonia.Input;
 using Microsoft.Toolkit.Mvvm.ComponentModel;
 using Microsoft.Toolkit.Mvvm.Messaging;
 using SS14.Launcher.Models.Data;
@@ -49,6 +50,7 @@ public sealed class ServerEntryViewModel : ObservableRecipient, IRecipient<Favor
 
     public void ConnectPressed()
     {
+        FocusManager.Instance?.Focus(null);
         ConnectingViewModel.StartConnect(_windowVm, Address);
     }
 


### PR DESCRIPTION
Fixes #86

After clicking Connect the connect button would still be focused and if you pressed Space/Enter you would trigger the connect again, causing an exception and crashing the client. Now we just unfocus right after the button is clicked so that that's no longer possible.