### PR TITLE
Change log level for duplicate server message

### DIFF
--- a/SS14.Launcher/Models/ServerStatus/ServerListCache.cs
+++ b/SS14.Launcher/Models/ServerStatus/ServerListCache.cs
@@ -121,7 +121,7 @@ public sealed class ServerListCache : ReactiveObject, IServerSource
                     var maybeNewEntry = new HubServerListEntry(entry.Address, hub.AbsoluteUri, entry.StatusData);
                     if (!entries.Add(maybeNewEntry))
                     {
-                        Log.Debug("Not adding {Entry} from {ThisHub} because it was already provided by {PreviousHub}",
+                        Log.Verbose("Not adding {Entry} from {ThisHub} because it was already provided by {PreviousHub}",
                             entry.Address,
                             hub.AbsoluteUri,
                             maybeNewEntry.HubAddress);


### PR DESCRIPTION
It can be kinda spammy right now and usually isn't very useful