### PR TITLE
fix package.nix postInstall and make more robust

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -130,7 +130,7 @@ buildDotnetModule rec {
 
   postInstall = ''
     mkdir -p $out/lib/space-station-14-launcher/loader
-    cp -r SS14.Loader/bin/${buildType}/net7.0/* $out/lib/space-station-14-launcher/loader/
+    cp -r SS14.Loader/bin/${buildType}/*/*/* $out/lib/space-station-14-launcher/loader/
 
     icoFileToHiColorTheme SS14.Launcher/Assets/icon.ico space-station-14-launcher $out
   '';


### PR DESCRIPTION
fixes error
```
System.ComponentModel.Win32Exception (2): An error occurred trying to start process '/nix/store/8l4hwg4r9qhqy3g02hb80f54czqaq1al-space-station-14-launcher-0.24.0/lib/space-station-14-launcher/loader/SS14.Loader' with working directory '/home/lizelive/thirdparty/SS14.Launcher'. No such file or directory
   at System.Diagnostics.Process.ForkAndExecProcess(ProcessStartInfo startInfo, String resolvedFilename, String[] argv, String[] envp, String cwd, Boolean setCredentials, UInt32 userId, UInt32 groupId, UInt32[] groups, Int32& stdinFd, Int32& stdoutFd, Int32& stderrFd, Boolean usesTerminal, Boolean throwOnNoExec)
   at System.Diagnostics.Process.StartCore(ProcessStartInfo startInfo)
   at System.Diagnostics.Process.Start(ProcessStartInfo startInfo)
   at SS14.Launcher.Models.Connector.LaunchClient(ContentLaunchInfo launchInfo, IEnumerable`1 extraArgs, List`1 env) in /build/source/SS14.Launcher/Models/Connector.cs:line 497
   at SS14.Launcher.Models.Connector.ConnectLaunchClient(ContentLaunchInfo launchInfo, ServerInfo info, ServerBuildInformation serverBuildInformation, Uri connectAddress, Uri parsedAddr, Boolean contentBundle) in /build/source/SS14.Launcher/Models/Connector.cs:line 296
   ```