### PR TITLE
Add build property to use system SQLite

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,9 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Launcher-loader shared stuff -->
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="7.0.4"/>
+    <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="7.0.4" />
+    <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.4" Condition="'$(UseSystemSqlite)' != 'True'" />
+    <PackageVersion Include="SQLitePCLRaw.provider.sqlite3" Version="2.1.4" Condition="'$(UseSystemSqlite)' == 'True'" />
     <PackageVersion Include="NSec.Cryptography" Version="22.4.0"/>
     <PackageVersion Include="SharpZstd.Interop" Version="1.5.2-beta2"/>
     <PackageVersion Include="JetBrains.Annotations" Version="2023.2.0-eap3" />

--- a/SS14.Launcher/Program.cs
+++ b/SS14.Launcher/Program.cs
@@ -1,3 +1,4 @@
+using Microsoft.Data.Sqlite;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -41,6 +42,9 @@ internal static class Program
         Console.OutputEncoding = Encoding.UTF8;
 #endif
 
+#if USE_SYSTEM_SQLITE
+        SQLitePCL.raw.SetProvider(new SQLitePCL.SQLite3Provider_sqlite3());
+#endif
         var msgr = new LauncherMessaging();
         Locator.CurrentMutable.RegisterConstant(msgr);
 

--- a/SS14.Launcher/SS14.Launcher.csproj
+++ b/SS14.Launcher/SS14.Launcher.csproj
@@ -11,6 +11,12 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>CA1416</NoWarn>
   </PropertyGroup>
+  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('FreeBSD'))">
+    <UseSystemSqlite>True</UseSystemSqlite>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(UseSystemSqlite)' == 'True'">
+    <DefineConstants>$(DefineConstants);USE_SYSTEM_SQLITE</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Update="**\*.xaml.cs">
       <DependentUpon>%(Filename)</DependentUpon>
@@ -38,7 +44,9 @@
     <PackageReference Include="CodeHollow.FeedReader" />
     <PackageReference Include="Dapper" />
     <PackageReference Include="DynamicData" />
-    <PackageReference Include="Microsoft.Data.Sqlite" />
+    <PackageReference Include="Microsoft.Data.Sqlite.Core" />
+    <PackageReference Include="SQLitePCLRaw.provider.sqlite3" Condition="'$(UseSystemSqlite)' == 'True'" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Condition="'$(UseSystemSqlite)' != 'True'" />
     <PackageReference Include="Microsoft.Toolkit.Mvvm" />
     <PackageReference Include="ReactiveUI" />
     <PackageReference Include="ReactiveUI.Fody" />

--- a/SS14.Loader/SS14.Loader.csproj
+++ b/SS14.Loader/SS14.Loader.csproj
@@ -21,7 +21,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" />
+    <PackageReference Include="Microsoft.Data.Sqlite.Core" />
+    <PackageReference Include="SQLitePCLRaw.provider.sqlite3" Condition="'$(UseSystemSqlite)' == 'True'" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Condition="'$(UseSystemSqlite)' != 'True'" />
     <PackageReference Include="NSec.Cryptography" />
     <PackageReference Include="Robust.Natives" />
     <PackageReference Include="SharpZstd.Interop" />


### PR DESCRIPTION
This is needed for the launcher to work on platforms without a bundled sqlite native library, including FreeBSD.