### PR TITLE
Fix canceling the replay file dialog causing a crash

### DIFF
--- a/SS14.Launcher/Views/MainWindowTabs/HomePageView.xaml.cs
+++ b/SS14.Launcher/Views/MainWindowTabs/HomePageView.xaml.cs
@@ -56,7 +56,7 @@ public partial class HomePageView : UserControl
         };
 
         var result = await dialog.ShowAsync(window);
-        if (result == null)
+        if (result == null || result.Length == 0) // Canceled
             return;
 
         var file = result[0];


### PR DESCRIPTION
To reproduce the bug this PR fixes:

1. Click "Run content/replay bundle"
2. When Windows file explorer opens for you to select the bundle, click Cancel instead
3. Launcher crashes due to the out-of-bounds exception since `result.Length == 0`