### PR TITLE
Displays reported panic bunker status for listed servers

### DIFF
--- a/SS14.Launcher/Api/ServerApi.cs
+++ b/SS14.Launcher/Api/ServerApi.cs
@@ -13,6 +13,8 @@ public static class ServerApi
         int PlayerCount,
         [property: JsonPropertyName("soft_max_players")]
         int SoftMaxPlayerCount,
+        [property: JsonPropertyName("panic_bunker")]
+        bool? PanicBunker,
         [property: JsonPropertyName("tags")] string[]? Tags);
 
     /// <summary>

--- a/SS14.Launcher/Models/ServerStatus/IServerStatusData.cs
+++ b/SS14.Launcher/Models/ServerStatus/IServerStatusData.cs
@@ -25,4 +25,6 @@ public interface IServerStatusData : INotifyPropertyChanged
     int PlayerCount { get; set; }
 
     int SoftMaxPlayerCount { get; set; }
+
+    bool? PanicBunker { get; set; }
 }

--- a/SS14.Launcher/Models/ServerStatus/ServerStatusCache.Data.cs
+++ b/SS14.Launcher/Models/ServerStatus/ServerStatusCache.Data.cs
@@ -11,6 +11,7 @@ public sealed class ServerStatusData : ObservableObject, IServerStatusData
     private TimeSpan? _ping;
     private int _playerCount;
     private int _softMaxPlayerCount;
+    private bool? _panicBunker;
     private ServerStatusCode _status = ServerStatusCode.FetchingStatus;
     private ServerStatusInfoCode _statusInfo = ServerStatusInfoCode.NotFetched;
     private ServerInfoLink[]? _links;
@@ -75,6 +76,12 @@ public sealed class ServerStatusData : ObservableObject, IServerStatusData
     {
         get => _softMaxPlayerCount;
         set => SetProperty(ref _softMaxPlayerCount, value);
+    }
+
+    public bool? PanicBunker
+    {
+        get => _panicBunker;
+        set => SetProperty(ref _panicBunker, value);
     }
 
     public ServerInfoLink[]? Links

--- a/SS14.Launcher/Models/ServerStatus/ServerStatusCache.cs
+++ b/SS14.Launcher/Models/ServerStatus/ServerStatusCache.cs
@@ -123,6 +123,7 @@ public sealed class ServerStatusCache : IServerSource
         data.Name = status.Name;
         data.PlayerCount = status.PlayerCount;
         data.SoftMaxPlayerCount = status.SoftMaxPlayerCount;
+        data.PanicBunker = status.PanicBunker;
 
         var baseTags = status.Tags ?? Array.Empty<string>();
         var inferredTags = ServerTagInfer.InferTags(status);

--- a/SS14.Launcher/Utility/ServerFilter.cs
+++ b/SS14.Launcher/Utility/ServerFilter.cs
@@ -57,4 +57,5 @@ public enum ServerFilterCategory : byte
     EighteenPlus = 4,
     PlayerCount = 5,
     Hub = 6,
+    Bunker = 7,
 }

--- a/SS14.Launcher/ViewModels/MainWindowTabs/ServerEntryViewModel.cs
+++ b/SS14.Launcher/ViewModels/MainWindowTabs/ServerEntryViewModel.cs
@@ -79,14 +79,19 @@ public sealed class ServerEntryViewModel : ObservableRecipient, IRecipient<Favor
                 case ServerStatusCode.Offline:
                     return "OFFLINE";
                 case ServerStatusCode.Online:
+                    var statusappend = $"";
+                    if (_cacheData.PanicBunker == null)
+                        statusappend += " ?";
+                    else if (_cacheData.PanicBunker == true)
+                        statusappend += " 🔒";
                     // Give a ratio for servers with a defined player count, or just a current number for those without.
                     if (_cacheData.SoftMaxPlayerCount > 0)
                     {
-                        return $"{_cacheData.PlayerCount} / {_cacheData.SoftMaxPlayerCount}";
+                        return $"{_cacheData.PlayerCount} / {_cacheData.SoftMaxPlayerCount}{statusappend}";
                     }
                     else
                     {
-                        return $"{_cacheData.PlayerCount} / ∞";
+                        return $"{_cacheData.PlayerCount} / ∞ {statusappend}";
                     }
                 case ServerStatusCode.FetchingStatus:
                     return "Fetching...";
@@ -210,6 +215,7 @@ public sealed class ServerEntryViewModel : ObservableRecipient, IRecipient<Favor
         {
             case nameof(IServerStatusData.PlayerCount):
             case nameof(IServerStatusData.SoftMaxPlayerCount):
+            case nameof(IServerStatusData.PanicBunker):
                 OnPropertyChanged(nameof(ServerStatusString));
                 break;
 

--- a/SS14.Launcher/ViewModels/MainWindowTabs/ServerEntryViewModel.cs
+++ b/SS14.Launcher/ViewModels/MainWindowTabs/ServerEntryViewModel.cs
@@ -83,7 +83,7 @@ public sealed class ServerEntryViewModel : ObservableRecipient, IRecipient<Favor
                     if (_cacheData.PanicBunker == null)
                         statusappend += " ?";
                     else if (_cacheData.PanicBunker == true)
-                        statusappend += " 🔒";
+                        statusappend += " 🔒"; //TODO: replace this with a proper lock icon. we know Visne's currently working on iconing up the launcher in #126; they might be interested in giving this a proper icon
                     // Give a ratio for servers with a defined player count, or just a current number for those without.
                     if (_cacheData.SoftMaxPlayerCount > 0)
                     {

--- a/SS14.Launcher/ViewModels/MainWindowTabs/ServerListFiltersViewModel.cs
+++ b/SS14.Launcher/ViewModels/MainWindowTabs/ServerListFiltersViewModel.cs
@@ -25,12 +25,14 @@ public sealed partial class ServerListFiltersViewModel : ObservableObject
     private readonly FilterListCollection _filtersRolePlay = new();
     private readonly FilterListCollection _filtersEighteenPlus = new();
     private readonly FilterListCollection _filtersHub = new();
+    private readonly FilterListCollection _filtersBunker = new();
 
     public ObservableCollection<ServerFilterViewModel> FiltersLanguage => _filtersLanguage;
     public ObservableCollection<ServerFilterViewModel> FiltersRegion => _filtersRegion;
     public ObservableCollection<ServerFilterViewModel> FiltersRolePlay => _filtersRolePlay;
     public ObservableCollection<ServerFilterViewModel> FiltersEighteenPlus => _filtersEighteenPlus;
     public ObservableCollection<ServerFilterViewModel> FiltersHub => _filtersHub;
+    public ObservableCollection<ServerFilterViewModel> FiltersBunker => _filtersBunker;
 
     public ServerFilterViewModel FilterPlayerCountHideEmpty { get; }
     public ServerFilterViewModel FilterPlayerCountHideFull { get; }
@@ -59,6 +61,11 @@ public sealed partial class ServerListFiltersViewModel : ObservableObject
             new ServerFilter(ServerFilterCategory.EighteenPlus, ServerFilter.DataTrue), this));
         FiltersEighteenPlus.Add(new ServerFilterViewModel("No", "No",
             new ServerFilter(ServerFilterCategory.EighteenPlus, ServerFilter.DataFalse), this));
+
+        FiltersBunker.Add(new ServerFilterViewModel("Yes", "Yes",
+            new ServerFilter(ServerFilterCategory.Bunker, ServerFilter.DataTrue), this));
+        FiltersBunker.Add(new ServerFilterViewModel("No", "No",
+            new ServerFilter(ServerFilterCategory.Bunker, ServerFilter.DataFalse), this));
 
         FilterPlayerCountHideEmpty = new ServerFilterViewModel(
             "Servers with no players will not be shown",
@@ -256,6 +263,21 @@ public sealed partial class ServerListFiltersViewModel : ObservableObject
                 eighteenPlus = false;
         }
 
+        bool? panicBunker = null;
+        if (GetFilter(ServerFilterCategory.Bunker, ServerFilter.DataTrue))
+        {
+            panicBunker = true;
+        }
+
+        if (GetFilter(ServerFilterCategory.Bunker, ServerFilter.DataFalse))
+        {
+            // Having both
+            if (panicBunker == true)
+                panicBunker = null;
+            else
+                panicBunker = false;
+        }
+
         for (var i = 0; i < list.Count; i++)
         {
             var server = list[i];
@@ -275,6 +297,12 @@ public sealed partial class ServerListFiltersViewModel : ObservableObject
             {
                 var serverEighteenPlus = server.Tags.Contains(Tags.TagEighteenPlus);
                 if (eighteenPlus != serverEighteenPlus)
+                    return false;
+            }
+
+            if (panicBunker != null)
+            {
+                if (panicBunker != server.PanicBunker)
                     return false;
             }
 

--- a/SS14.Launcher/Views/MainWindowTabs/ServerListFiltersView.xaml
+++ b/SS14.Launcher/Views/MainWindowTabs/ServerListFiltersView.xaml
@@ -56,6 +56,11 @@
           <ItemsControl ItemsSource="{Binding FiltersEighteenPlus}"
                         ItemsPanel="{StaticResource PanelTemplate}" ItemTemplate="{StaticResource FilterTemplate}"/>
         </DockPanel>
+        <DockPanel Classes="ServerFilterGroup">
+          <TextBlock MinWidth="150" DockPanel.Dock="Left" VerticalAlignment="Center" Classes="SubText" Text="Panic Bunker" />
+          <ItemsControl ItemsSource="{Binding FiltersBunker}"
+                        ItemsPanel="{StaticResource PanelTemplate}" ItemTemplate="{StaticResource FilterTemplate}"/>
+        </DockPanel>
 
         <DockPanel Classes="ServerFilterGroup">
           <TextBlock MinWidth="150" DockPanel.Dock="Left" Classes="SubText" Text="Hub" />


### PR DESCRIPTION
Title! This is basically just the launcher-side followup to space-wizards/space-station-14/pull/23330

After these changes, the server list looks like this:
![dotnet_rEIxDWolqN](https://github.com/space-wizards/SS14.Launcher/assets/6356337/3e86844d-cd75-4fe7-92cd-752607bf706c)

Servers with the panic bunker enabled will have a lock emoji (influenced by installed fonts. this should 100% be replaced with a proper system-agnostic icon at some point; perhaps #126 might be able to do this?) alongside their playercount. Those that have their panic bunker disabled will have no marks. Servers that have an unknown panic bunker status (caused by the server not reporting panic bunker status at all) will display a question mark. Displaying the question mark directly encourages servers to report their panic bunker status proper, which in turn makes it far more clear which servers can just be joined and which ones aren't accepting new players.

This in turn will make joining servers a *lot* more clear for new players who probably won't know what a panic bunker is; quite a few new players on the Discord have expressed being immensely confused of why they're unable to join the main servers, so this gives a far clearer indicator to new players of "Hey, this server might not be available to you"

Additionally, this includes the option to filter the server list by panic bunker status!
![dotnet_owInk7j4pl](https://github.com/space-wizards/SS14.Launcher/assets/6356337/1d4ddd8e-09b3-4dcc-ad9c-a98f41ca2b78)
