### PR TITLE
Integrate sentry into the launcher

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,41 +5,42 @@
   <ItemGroup>
     <!-- Launcher-loader shared stuff -->
     <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="7.0.4" />
+    <PackageVersion Include="Sentry.Serilog" Version="3.41.3" />
     <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.4" Condition="'$(UseSystemSqlite)' != 'True'" />
     <PackageVersion Include="SQLitePCLRaw.provider.sqlite3" Version="2.1.4" Condition="'$(UseSystemSqlite)' == 'True'" />
-    <PackageVersion Include="NSec.Cryptography" Version="22.4.0"/>
-    <PackageVersion Include="SharpZstd.Interop" Version="1.5.2-beta2"/>
+    <PackageVersion Include="NSec.Cryptography" Version="22.4.0" />
+    <PackageVersion Include="SharpZstd.Interop" Version="1.5.2-beta2" />
     <PackageVersion Include="JetBrains.Annotations" Version="2023.2.0-eap3" />
     <PackageVersion Include="Microsoft.NET.ILLink.Tasks" Version="8.0.0" />
     <!-- Loader -->
-    <PackageVersion Include="Robust.Natives" Version="0.1.1"/>
+    <PackageVersion Include="Robust.Natives" Version="0.1.1" />
     <!-- Launcher -->
-    <PackageVersion Include="Avalonia" Version="11.0.5"/>
-    <PackageVersion Include="Avalonia.Desktop" Version="11.0.5"/>
-    <PackageVersion Include="Avalonia.ReactiveUI" Version="11.0.5"/>
-    <PackageVersion Include="Avalonia.Diagnostics" Version="11.0.5"/>
-    <PackageVersion Include="Avalonia.Themes.Simple" Version="11.0.5"/>
-    <PackageVersion Include="CodeHollow.FeedReader" Version="1.2.6"/>
-    <PackageVersion Include="Dapper" Version="2.0.123"/>
-    <PackageVersion Include="DynamicData" Version="7.13.1"/>
-    <PackageVersion Include="Microsoft.Toolkit.Mvvm" Version="7.1.2"/>
-    <PackageVersion Include="ReactiveUI" Version="18.4.26"/>
-    <PackageVersion Include="ReactiveUI.Fody" Version="18.4.26"/>
-    <PackageVersion Include="Robust.Shared.AuthLib" Version="0.1.2"/>
-    <PackageVersion Include="Serilog" Version="2.12.0"/>
-    <PackageVersion Include="Serilog.Sinks.Console" Version="4.1.0"/>
-    <PackageVersion Include="Serilog.Sinks.File" Version="5.0.0"/>
-    <PackageVersion Include="YamlDotNet" Version="13.0.2"/>
-    <PackageVersion Include="TerraFX.Interop.Windows" Version="10.0.22621.1"/>
-    <PackageVersion Include="Mono.Posix.NETStandard" Version="1.0.0"/>
-    <PackageVersion Include="SpaceWizards.Sodium" Version="0.2.1"/>
+    <PackageVersion Include="Avalonia" Version="11.0.5" />
+    <PackageVersion Include="Avalonia.Desktop" Version="11.0.5" />
+    <PackageVersion Include="Avalonia.ReactiveUI" Version="11.0.5" />
+    <PackageVersion Include="Avalonia.Diagnostics" Version="11.0.5" />
+    <PackageVersion Include="Avalonia.Themes.Simple" Version="11.0.5" />
+    <PackageVersion Include="CodeHollow.FeedReader" Version="1.2.6" />
+    <PackageVersion Include="Dapper" Version="2.0.123" />
+    <PackageVersion Include="DynamicData" Version="7.13.1" />
+    <PackageVersion Include="Microsoft.Toolkit.Mvvm" Version="7.1.2" />
+    <PackageVersion Include="ReactiveUI" Version="18.4.26" />
+    <PackageVersion Include="ReactiveUI.Fody" Version="18.4.26" />
+    <PackageVersion Include="Robust.Shared.AuthLib" Version="0.1.2" />
+    <PackageVersion Include="Serilog" Version="2.12.0" />
+    <PackageVersion Include="Serilog.Sinks.Console" Version="4.1.0" />
+    <PackageVersion Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageVersion Include="YamlDotNet" Version="13.0.2" />
+    <PackageVersion Include="TerraFX.Interop.Windows" Version="10.0.22621.1" />
+    <PackageVersion Include="Mono.Posix.NETStandard" Version="1.0.0" />
+    <PackageVersion Include="SpaceWizards.Sodium" Version="0.2.1" />
     <PackageVersion Include="System.Net.Http.WinHttpHandler" Version="8.0.0" />
     <!-- Test stuff -->
-    <PackageVersion Include="nunit" Version="3.13.3"/>
-    <PackageVersion Include="NUnit.Analyzers" Version="3.6.1"/>
-    <PackageVersion Include="NUnit3TestAdapter" Version="4.4.2"/>
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.5.0"/>
+    <PackageVersion Include="nunit" Version="3.13.3" />
+    <PackageVersion Include="NUnit.Analyzers" Version="3.6.1" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="4.4.2" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <!-- Bootstrap -->
-    <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3"/>
+    <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
   </ItemGroup>
 </Project>

--- a/SS14.Launcher/Models/Data/CVars.cs
+++ b/SS14.Launcher/Models/Data/CVars.cs
@@ -67,6 +67,16 @@ public static class CVars
     public static readonly CVarDef<bool> LogLauncherVerbose = CVarDef.Create("LogLauncherVerbose", false);
 
     /// <summary>
+    /// Sentry error reporting
+    /// </summary>
+    public static readonly CVarDef<bool> EnableSentry = CVarDef.Create("EnableSentry", true);
+
+    /// <summary>
+    /// The DSN used for sentry.
+    /// </summary>
+    public static readonly CVarDef<string> SentryDsn = CVarDef.Create("SentryDsn", "");
+
+    /// <summary>
     /// Enable multi-account support on release builds.
     /// </summary>
     public static readonly CVarDef<bool> MultiAccounts = CVarDef.Create("MultiAccounts", false);

--- a/SS14.Launcher/Program.cs
+++ b/SS14.Launcher/Program.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
 using System.Linq;
 using System.Net.Http.Headers;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;

--- a/SS14.Launcher/SS14.Launcher.csproj
+++ b/SS14.Launcher/SS14.Launcher.csproj
@@ -46,6 +46,7 @@
     <PackageReference Include="Dapper" />
     <PackageReference Include="DynamicData" />
     <PackageReference Include="Microsoft.Data.Sqlite.Core" />
+    <PackageReference Include="Sentry.Serilog" />
     <PackageReference Include="SQLitePCLRaw.provider.sqlite3" Condition="'$(UseSystemSqlite)' == 'True'" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Condition="'$(UseSystemSqlite)' != 'True'" />
     <PackageReference Include="Microsoft.Toolkit.Mvvm" />

--- a/SS14.Launcher/Utility/SentryExceptionFilter.cs
+++ b/SS14.Launcher/Utility/SentryExceptionFilter.cs
@@ -8,7 +8,6 @@ public static class SentryExceptionFilter
 {
     private static IEnumerable<string> IgnoredSentryMessageFilter => new[]
     {
-        //"ThisWillNeverAppear"
         "HappyEyeballsHttp"
     };
 

--- a/SS14.Launcher/Utility/SentryExceptionFilter.cs
+++ b/SS14.Launcher/Utility/SentryExceptionFilter.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+using Sentry;
+// ReSharper disable LoopCanBeConvertedToQuery
+
+namespace SS14.Launcher.Utility;
+
+public static class SentryExceptionFilter
+{
+    private static IEnumerable<string> IgnoredSentryMessageFilter => new[]
+    {
+        //"ThisWillNeverAppear"
+        "HappyEyeballsHttp"
+    };
+
+    public static void SetupFilters(this SentryOptions options)
+    {
+        options.SetBeforeSend(FilterExceptions);
+    }
+
+    private static SentryEvent? FilterExceptions(SentryEvent? sentryEvent, Hint hint)
+    {
+        foreach (var excluded in IgnoredSentryMessageFilter)
+        {
+            if (sentryEvent?.Message?.Message?.Contains(excluded) ?? false)
+                return null;
+        }
+
+        return sentryEvent;
+    }
+}


### PR DESCRIPTION
Exception will get sent to the sentry instance the set DSN is from.
The Sentry integration can be enabled and disabled using a cvar as well as the DSN is set using a cvar.
![image](https://github.com/space-wizards/SS14.Launcher/assets/8915246/048cc7e7-d5da-43eb-a217-1f304874fc6c)
