### PR TITLE
Fix typo in translations docs url

### DIFF
--- a/SS14.Launcher/ConfigConstants.cs
+++ b/SS14.Launcher/ConfigConstants.cs
@@ -36,7 +36,7 @@ public static class ConfigConstants
     public const string WebsiteUrl = "https://spacestation14.com";
     public const string DownloadUrl = "https://spacestation14.com/about/nightlies/";
     public const string NewsFeedUrl = "https://spacestation14.com/post/index.xml";
-    public const string TranslateUrl = "https://do cs.spacestation14.com/en/general-development/contributing-translations.html";
+    public const string TranslateUrl = "https://docs.spacestation14.com/en/general-development/contributing-translations.html";
 
     private static readonly UrlFallbackSet RobustBuildsBaseUrl = new([
         "https://robust-builds.cdn.spacestation14.com/",


### PR DESCRIPTION
These really shouldn't be strings and should use the standard uri type instead. It tries to parse the string as uri every time the button is pressed, which currently crashes due to the typo.