### PR TITLE
Remove dotnet SDK 6.0 dependency.

### DIFF
--- a/SS14.Launcher.FakeRobustToolbox/Robust.Client/Robust.Client.csproj
+++ b/SS14.Launcher.FakeRobustToolbox/Robust.Client/Robust.Client.csproj
@@ -5,7 +5,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
After #162, this updates the only remaining project requiring dotnet 6.0. 

This also removes 6.0 from the nix package.