### PR TITLE
Add system memory to launcher diagnostics

### DIFF
--- a/SS14.Launcher/LauncherDiagnostics.cs
+++ b/SS14.Launcher/LauncherDiagnostics.cs
@@ -28,6 +28,8 @@ internal static class LauncherDiagnostics
             "Processor: {ProcessorCount}x {ProcessorModel}",
             Environment.ProcessorCount,
             GetProcessorModel());
+        Log.Information("System Memory: {TotalMemory} MiB",
+            GC.GetGCMemoryInfo().TotalAvailableMemoryBytes / 1024 / 1024);
 
         Log.Information("SQLite version: {SqliteVersion}", raw.sqlite3_libversion().utf8_to_string());
     }


### PR DESCRIPTION
I can't believe it's just a burning memory
<img width="439" alt="Screenshot 2024-07-27 at 12 24 00 AM" src="https://github.com/user-attachments/assets/6c7c9e76-7c93-4198-b2a7-c411f92c6f2a">
