### PR TITLE
Add tooltips with URL to server info buttons

### DIFF
--- a/SS14.Launcher/Views/ServerInfoLinkControl.xaml
+++ b/SS14.Launcher/Views/ServerInfoLinkControl.xaml
@@ -9,7 +9,7 @@
   <Design.DataContext>
     <models:ServerInfoLink />
   </Design.DataContext>
-  <Button Click="Button_OnClick" HorizontalContentAlignment="Stretch">
+  <Button Click="Button_OnClick" HorizontalContentAlignment="Stretch" ToolTip.Tip="{Binding Url}">
     <views:IconLabel Name="IconLabel" Content="{Binding Name}" />
   </Button>
 </UserControl>


### PR DESCRIPTION
For the buttons in the server info, adds a tooltip showing the URL you'll be brought to on clicking.

![2024-09-13_22-59](https://github.com/user-attachments/assets/f756f759-a5a1-45c3-aac8-165c92d6c106)
