### PR TITLE
SS14.Loader fixes for FreeBSD

### DIFF
--- a/SS14.Launcher/Models/Connector.cs
+++ b/SS14.Launcher/Models/Connector.cs
@@ -600,7 +600,7 @@ public class Connector : ReactiveObject
                 "SS14.Loader", "bin", "Debug", "net8.0"));
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD))
         {
             return new ProcessStartInfo
             {

--- a/SS14.Loader/Program.cs
+++ b/SS14.Loader/Program.cs
@@ -56,7 +56,11 @@ internal class Program
         if (!TryGetLoader(clientAssembly, out var loader))
             return false;
 
+#if USE_SYSTEM_SQLITE
+        SQLitePCL.raw.SetProvider(new SQLitePCL.SQLite3Provider_sqlite3());
+#else
         SQLitePCL.Batteries_V2.Init();
+#endif
 
         var launcher = Environment.GetEnvironmentVariable("SS14_LAUNCHER_PATH");
         var redialApi = launcher != null ? new RedialApi(launcher) : null;

--- a/SS14.Loader/SS14.Loader.csproj
+++ b/SS14.Loader/SS14.Loader.csproj
@@ -8,6 +8,13 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
+  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('FreeBSD'))">
+    <UseSystemSqlite>True</UseSystemSqlite>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(UseSystemSqlite)' == 'True'">
+    <DefineConstants>$(DefineConstants);USE_SYSTEM_SQLITE</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Robust.LoaderApi\Robust.LoaderApi\Robust.LoaderApi.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Fixes SS14.Loader on FreeBSD:

- `USE_SYSTEM_SQLITE` was added for SS14.Loader a while ago, but wasn't actually set in the build properties. Define this correctly so that FreeBSD sets `USE_SYSTEM_SQLITE`
- Launch `SS14.Loader` like we're on Linux