### PR TITLE
Implement privacy policy support

### DIFF
--- a/SS14.Launcher/Assets/Locale/en-US/text.ftl
+++ b/SS14.Launcher/Assets/Locale/en-US/text.ftl
@@ -49,7 +49,7 @@ connecting-privacy-policy-text = This server requires that you accept its privac
 connecting-privacy-policy-text-version-changed = This server has updated its privacy policy since the last time you played. You must accept the new version before connecting.
 connecting-privacy-policy-view = View privacy policy
 connecting-privacy-policy-accept = Accept (continue)
-connecting-privacy-policy-deny = Deny (disconnect)
+connecting-privacy-policy-decline = Decline (disconnect)
 
 ## Strings for the "direct connect" dialog window.
 

--- a/SS14.Launcher/Assets/Locale/en-US/text.ftl
+++ b/SS14.Launcher/Assets/Locale/en-US/text.ftl
@@ -45,6 +45,12 @@ connecting-update-status-loading-into-db = Storing assets in database…
 connecting-update-status-loading-content-bundle = Loading content bundle…
 connecting-update-status-unknown = You shouldn't see this
 
+connecting-privacy-policy-text = This server requires that you accept its privacy policy before connecting.
+connecting-privacy-policy-text-version-changed = This server has updated its privacy policy since the last time you played. You must accept the new version before connecting.
+connecting-privacy-policy-view = View privacy policy
+connecting-privacy-policy-accept = Accept (continue)
+connecting-privacy-policy-deny = Deny (disconnect)
+
 ## Strings for the "direct connect" dialog window.
 
 direct-connect-title = Direct Connect…

--- a/SS14.Launcher/Helpers.cs
+++ b/SS14.Launcher/Helpers.cs
@@ -8,6 +8,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Mono.Unix;
+using Serilog;
 using TerraFX.Interop.Windows;
 
 namespace SS14.Launcher;
@@ -86,6 +87,27 @@ public static class Helpers
                 }
             } while (isMoreToRead);
         }, cancel);
+    }
+
+    /// <summary>
+    /// Open a URI provided by a game server in the user's browser. Refuse to open anything other than http/https.
+    /// </summary>
+    /// <param name="uri">The URI to open.</param>
+    public static void SafeOpenServerUri(string uri)
+    {
+        if (!Uri.TryCreate(uri, UriKind.Absolute, out var parsedUri))
+        {
+            Log.Error("Unable to parse URI in server-provided link: {Link}", uri);
+            return;
+        }
+
+        if (parsedUri.Scheme is not ("http" or "https"))
+        {
+            Log.Error("Refusing to open server-provided link {Link}, only http/https are allowed", parsedUri);
+            return;
+        }
+
+        OpenUri(parsedUri.ToString());
     }
 
     public static void OpenUri(Uri uri)

--- a/SS14.Launcher/Models/Connector.cs
+++ b/SS14.Launcher/Models/Connector.cs
@@ -38,6 +38,10 @@ public class Connector : ReactiveObject
     private bool _clientExitedBadly;
     private readonly HttpClient _http;
 
+    private TaskCompletionSource<PrivacyPolicyAcceptResult>? _acceptPrivacyPolicyTcs;
+    private ServerPrivacyPolicyInfo? _serverPrivacyPolicyInfo;
+    private bool _privacyPolicyDifferentVersion;
+
     public Connector()
     {
         _updater = Locator.Current.GetRequiredService<Updater>();
@@ -59,6 +63,13 @@ public class Connector : ReactiveObject
         private set => this.RaiseAndSetIfChanged(ref _clientExitedBadly, value);
     }
 
+    public ServerPrivacyPolicyInfo? PrivacyPolicyInfo => _serverPrivacyPolicyInfo;
+    public bool PrivacyPolicyDifferentVersion
+    {
+        get => _privacyPolicyDifferentVersion;
+        private set => this.RaiseAndSetIfChanged(ref _privacyPolicyDifferentVersion, value);
+    }
+
     public async void Connect(string address, CancellationToken cancel = default)
     {
         try
@@ -74,6 +85,10 @@ public class Connector : ReactiveObject
         {
             Log.Information(e, "Cancelled connect");
             Status = ConnectionStatus.Cancelled;
+        }
+        finally
+        {
+            Cleanup();
         }
     }
 
@@ -95,6 +110,10 @@ public class Connector : ReactiveObject
             Log.Information(e, "Cancelled launch");
             Status = ConnectionStatus.Cancelled;
         }
+        finally
+        {
+            Cleanup();
+        }
     }
 
     private async Task ConnectInternalAsync(string address, CancellationToken cancel)
@@ -102,6 +121,8 @@ public class Connector : ReactiveObject
         Status = ConnectionStatus.Connecting;
 
         var (info, parsedAddr, infoAddr) = await GetServerInfoAsync(address, cancel);
+
+        await HandlePrivacyPolicyAsync(info, cancel);
 
         // Run update.
         Status = ConnectionStatus.Updating;
@@ -111,6 +132,80 @@ public class Connector : ReactiveObject
         var connectAddress = GetConnectAddress(info, infoAddr);
 
         await LaunchClientWrap(installation, info, info.BuildInformation, connectAddress, parsedAddr, false, cancel);
+    }
+
+    private async Task HandlePrivacyPolicyAsync(ServerInfo info, CancellationToken cancel)
+    {
+        if (info.PrivacyPolicy == null)
+        {
+            // Server has no privacy policy configured, nothing to do.
+            return;
+        }
+
+        var identifier = info.PrivacyPolicy.Identifier;
+        var version = info.PrivacyPolicy.Version;
+
+        if (_cfg.HasAcceptedPrivacyPolicy(identifier, out var acceptedVersion))
+        {
+            if (version == acceptedVersion)
+            {
+                Log.Debug(
+                    "User has previously accepted privacy policy {Identifier} with version {Version}",
+                    identifier,
+                    acceptedVersion);
+
+                // User has previously accepted privacy policy, update last connected time in DB at least.
+                _cfg.UpdateConnectedToPrivacyPolicy(identifier);
+                _cfg.CommitConfig();
+                return;
+            }
+            else
+            {
+                Log.Debug("User previously accepted privacy policy but version has changed!");
+                PrivacyPolicyDifferentVersion = true;
+            }
+        }
+
+        // Ask user for privacy policy acceptance by waiting here.
+        Log.Debug("Prompting user for privacy policy acceptance: {Identifer} version {Version}", identifier, version);
+        _serverPrivacyPolicyInfo = info.PrivacyPolicy;
+        _acceptPrivacyPolicyTcs = new TaskCompletionSource<PrivacyPolicyAcceptResult>();
+
+        Status = ConnectionStatus.AwaitingPrivacyPolicyAcceptance;
+        var result = await _acceptPrivacyPolicyTcs.Task.WaitAsync(cancel);
+
+        if (result == PrivacyPolicyAcceptResult.Accepted)
+        {
+            // Yippee they're ok with it.
+            Log.Debug("User accepted privacy policy");
+            _cfg.AcceptPrivacyPolicy(identifier, version);
+            _cfg.CommitConfig();
+            return;
+        }
+
+        // They're not ok with it. Just throw cancellation so the code cleans up I guess.
+        // We could just have the connection screen treat "deny" as a cancellation op directly,
+        // but that would make the logs less clear.
+        Log.Information("User denied privacy policy, cancelling connection attempt!");
+        throw new OperationCanceledException();
+    }
+
+    public void ConfirmPrivacyPolicy(PrivacyPolicyAcceptResult result)
+    {
+        if (_acceptPrivacyPolicyTcs == null)
+        {
+            Log.Error("_acceptPrivacyPolicyTcs is null???");
+            return;
+        }
+
+        _acceptPrivacyPolicyTcs.SetResult(result);
+    }
+
+    private void Cleanup()
+    {
+        _serverPrivacyPolicyInfo = null;
+        _acceptPrivacyPolicyTcs = null;
+        PrivacyPolicyDifferentVersion = default;
     }
 
     private async Task LaunchContentBundleInternal(IStorageFile file, CancellationToken cancel)
@@ -668,6 +763,7 @@ public class Connector : ReactiveObject
         Updating,
         UpdateError,
         Connecting,
+        AwaitingPrivacyPolicyAcceptance,
         ConnectionFailed,
         StartingClient,
         ClientRunning,
@@ -710,3 +806,9 @@ public sealed record ContentBundleBaseBuild(
     [property: JsonPropertyName("manifest_url")] string? ManifestUrl,
     [property: JsonPropertyName("manifest_hash")] string? ManifestHash
 );
+
+public enum PrivacyPolicyAcceptResult
+{
+    Denied,
+    Accepted,
+}

--- a/SS14.Launcher/Models/Data/DataManager.cs
+++ b/SS14.Launcher/Models/Data/DataManager.cs
@@ -61,6 +61,9 @@ public sealed class DataManager : ReactiveObject
     private readonly List<DbCommand> _dbCommandQueue = new();
     private readonly SemaphoreSlim _dbWritingSemaphore = new(1);
 
+    // Privacy policy IDs accepted along with the last accepted version.
+    private readonly Dictionary<string, string> _acceptedPrivacyPolicies = new();
+
     static DataManager()
     {
         SqlMapper.AddTypeHandler(new GuidTypeHandler());
@@ -216,6 +219,43 @@ public sealed class DataManager : ReactiveObject
         CommitConfig();
     }
 
+    public bool HasAcceptedPrivacyPolicy(string privacyPolicy, [NotNullWhen(true)] out string? version)
+    {
+        return _acceptedPrivacyPolicies.TryGetValue(privacyPolicy, out version);
+    }
+
+    public void AcceptPrivacyPolicy(string privacyPolicy, string version)
+    {
+        if (_acceptedPrivacyPolicies.ContainsKey(privacyPolicy))
+        {
+            // Accepting new version
+            AddDbCommand(db => db.Execute("""
+                UPDATE AcceptedPrivacyPolicy
+                SET Version = @Version, LastConnected = DATETIME('now')
+                WHERE Identifier = @Identifier
+                """, new { Identifier = privacyPolicy, Version = version }));
+        }
+        else
+        {
+            // Accepting new privacy policy entirely.
+            AddDbCommand(db => db.Execute("""
+                INSERT OR REPLACE INTO AcceptedPrivacyPolicy (Identifier, Version, AcceptedTime, LastConnected)
+                VALUES (@Identifier, @Version, DATETIME('now'), DATETIME('now'))
+                """, new { Identifier = privacyPolicy, Version = version }));
+        }
+
+        _acceptedPrivacyPolicies[privacyPolicy] = version;
+    }
+
+    public void UpdateConnectedToPrivacyPolicy(string privacyPolicy)
+    {
+        AddDbCommand(db => db.Execute("""
+            UPDATE AcceptedPrivacyPolicy
+            SET LastConnected = DATETIME('now')
+            WHERE Version = @Version
+            """, new { Version = privacyPolicy }));
+    }
+
     /// <summary>
     ///     Loads config file from disk, or resets the loaded config to default if the config doesn't exist on disk.
     /// </summary>
@@ -292,6 +332,12 @@ public sealed class DataManager : ReactiveObject
 
         _filters.UnionWith(sqliteConnection.Query<ServerFilter>("SELECT Category, Data FROM ServerFilter"));
         _hubs.AddRange(sqliteConnection.Query<Hub>("SELECT Address,Priority FROM Hub"));
+
+        foreach (var (identifier, version) in sqliteConnection.Query<(string, string)>(
+                     "SELECT Identifier, Version FROM AcceptedPrivacyPolicy"))
+        {
+            _acceptedPrivacyPolicies[identifier] = version;
+        }
 
         // Avoid DB commands from config load.
         _dbCommandQueue.Clear();

--- a/SS14.Launcher/Models/Data/Migrations/Script0007_PrivacyPolicy.sql
+++ b/SS14.Launcher/Models/Data/Migrations/Script0007_PrivacyPolicy.sql
@@ -1,0 +1,17 @@
+-- Represents privacy policies that have been accepted by the user.
+-- Each policy is stored with its server-unique identifier and version value.
+CREATE TABLE AcceptedPrivacyPolicy(
+    -- The "identifier" field from the privacy_policy server info response.
+    Identifier TEXT NOT NULL PRIMARY KEY,
+
+    -- The "version" field from the privacy_policy server info response.
+    Version TEXT NOT NULL,
+
+    -- The time the user accepted the privacy policy for the first time.
+    AcceptedTime DATETIME NOT NULL,
+
+    -- The last time the user connected to a server using this privacy policy.
+    -- Intended to enable culling of this table for servers the user has not connected to in a long time,
+    -- though this is not currently implemented at the time of writing.
+    LastConnected DATETIME NOT NULL
+);

--- a/SS14.Launcher/Models/ServerInfo.cs
+++ b/SS14.Launcher/Models/ServerInfo.cs
@@ -15,6 +15,8 @@ public sealed class ServerInfo
 
     [JsonPropertyName("desc")] public string? Desc { get; set; }
     [JsonPropertyName("links")] public ServerInfoLink[]? Links { get; set; }
+
+    [JsonPropertyName("privacy_policy")] public ServerPrivacyPolicyInfo? PrivacyPolicy { get; set; }
 }
 
 public sealed record ServerInfoLink(string Name, string? Icon, string Url);
@@ -64,3 +66,10 @@ public enum AuthMode
     Required = 1,
     Disabled = 2
 }
+
+public sealed record ServerPrivacyPolicyInfo(
+    [property: JsonPropertyName("link")] string Link,
+    [property: JsonPropertyName("identifier")]
+    string Identifier,
+    [property: JsonPropertyName("version")]
+    string Version);

--- a/SS14.Launcher/Views/ConnectingOverlay.xaml
+++ b/SS14.Launcher/Views/ConnectingOverlay.xaml
@@ -55,7 +55,7 @@
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0 10">
           <Button Content="{loc:Loc 'connecting-privacy-policy-accept'}" Command="{Binding PrivacyPolicyAccept}"
                   Classes="OpenRight" />
-          <Button Content="{loc:Loc 'connecting-privacy-policy-deny'}" Command="{Binding PrivacyPolicyDeny}"
+          <Button Content="{loc:Loc 'connecting-privacy-policy-decline'}" Command="{Binding PrivacyPolicyDeny}"
                   Classes="OpenLeft"/>
         </StackPanel>
       </StackPanel>

--- a/SS14.Launcher/Views/ConnectingOverlay.xaml
+++ b/SS14.Launcher/Views/ConnectingOverlay.xaml
@@ -12,36 +12,53 @@
     <vm:ConnectingViewModel />
   </Design.DataContext>
   <ContentControl Classes="OverlayBox">
-    <StackPanel Orientation="Vertical">
-      <TextBlock HorizontalAlignment="Center" Classes="NanoHeadingMedium" Text="{Binding TitleText}" />
-      <TextBlock HorizontalAlignment="Center" Margin="0 10" DockPanel.Dock="Top" Text="{Binding StatusText}"
-                 TextWrapping="Wrap"  MaxWidth="400" />
-      <ProgressBar DockPanel.Dock="Bottom" Maximum="1" Value="{Binding Progress}"
-                   IsIndeterminate="{Binding ProgressIndeterminate}" IsVisible="{Binding ProgressBarVisible}"
-                   MinWidth="300" />
+    <Panel>
+      <StackPanel Orientation="Vertical" IsVisible="{Binding !IsAskingPrivacyPolicy}">
+        <TextBlock HorizontalAlignment="Center" Classes="NanoHeadingMedium" Text="{Binding TitleText}" />
+        <TextBlock HorizontalAlignment="Center" Margin="0 10" DockPanel.Dock="Top" Text="{Binding StatusText}"
+                   TextWrapping="Wrap"  MaxWidth="400" />
+        <ProgressBar DockPanel.Dock="Bottom" Maximum="1" Value="{Binding Progress}"
+                     IsIndeterminate="{Binding ProgressIndeterminate}" IsVisible="{Binding ProgressBarVisible}"
+                     MinWidth="300" />
 
-      <Panel DockPanel.Dock="Bottom">
-        <Button Content="Ok" IsVisible="{Binding IsErrored}" HorizontalAlignment="Center"
-                Command="{Binding ErrorDismissed}" MinWidth="75" />
+        <Panel DockPanel.Dock="Bottom">
+          <Button Content="Ok" IsVisible="{Binding IsErrored}" HorizontalAlignment="Center"
+                  Command="{Binding ErrorDismissed}" MinWidth="75" />
 
-        <DockPanel LastChildFill="False">
-          <Button DockPanel.Dock="Left"
-                  Name="CancelButton"
-                  Content="{loc:Loc connecting-cancel}"
-                  Command="{Binding Cancel}"
-                  IsVisible="{Binding !IsErrored}" />
+          <DockPanel LastChildFill="False">
+            <Button DockPanel.Dock="Left"
+                    Name="CancelButton"
+                    Content="{loc:Loc connecting-cancel}"
+                    Command="{Binding Cancel}"
+                    IsVisible="{Binding !IsErrored}" />
 
-          <TextBlock DockPanel.Dock="Right" Margin="8 4 0 4" Text="{Binding ProgressText}"
-                     TextWrapping="Wrap"
-                     IsVisible="{Binding !ProgressIndeterminate}" />
+            <TextBlock DockPanel.Dock="Right" Margin="8 4 0 4" Text="{Binding ProgressText}"
+                       TextWrapping="Wrap"
+                       IsVisible="{Binding !ProgressIndeterminate}" />
 
-          <TextBlock DockPanel.Dock="Right" Margin="0 4" Text="{Binding SpeedText}"
-                     TextWrapping="Wrap"
-                     IsVisible="{Binding !SpeedIndeterminate}" />
-        </DockPanel>
-      </Panel>
+            <TextBlock DockPanel.Dock="Right" Margin="0 4" Text="{Binding SpeedText}"
+                       TextWrapping="Wrap"
+                       IsVisible="{Binding !SpeedIndeterminate}" />
+          </DockPanel>
+        </Panel>
 
-      <views:RandomMessage Name="Messages" Margin="0 6 0 0" MaxWidth="250" />
-    </StackPanel>
+        <views:RandomMessage Name="Messages" Margin="0 6 0 0" MaxWidth="250" />
+      </StackPanel>
+      <StackPanel Orientation="Vertical" IsVisible="{Binding IsAskingPrivacyPolicy}">
+        <TextBlock HorizontalAlignment="Center" Classes="NanoHeadingMedium" Text="{Binding TitleText}" />
+        <TextBlock HorizontalAlignment="Center" Margin="0 10" DockPanel.Dock="Top" Text="{Binding PrivacyPolicyText}"
+                   TextWrapping="Wrap" MaxWidth="400" />
+
+        <Button Content="{loc:Loc 'connecting-privacy-policy-view'}" Command="{Binding PrivacyPolicyView}"
+                HorizontalAlignment="Center" />
+
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0 10">
+          <Button Content="{loc:Loc 'connecting-privacy-policy-accept'}" Command="{Binding PrivacyPolicyAccept}"
+                  Classes="OpenRight" />
+          <Button Content="{loc:Loc 'connecting-privacy-policy-deny'}" Command="{Binding PrivacyPolicyDeny}"
+                  Classes="OpenLeft"/>
+        </StackPanel>
+      </StackPanel>
+    </Panel>
   </ContentControl>
 </UserControl>

--- a/SS14.Launcher/Views/ServerInfoLinkControl.xaml.cs
+++ b/SS14.Launcher/Views/ServerInfoLinkControl.xaml.cs
@@ -30,19 +30,7 @@ public sealed partial class ServerInfoLinkControl : UserControl
         if (DataContext is not ServerInfoLink link)
             return;
 
-        if (!Uri.TryCreate(link.Url, UriKind.Absolute, out var uri))
-        {
-            Log.Error("Unable to parse URI in info link: {Link}", link.Url);
-            return;
-        }
-
-        if (uri.Scheme is not ("http" or "https"))
-        {
-            Log.Error("Refusing to open info link {Link}, only http/https are allowed", uri);
-            return;
-        }
-
-        Helpers.OpenUri(link.Url);
+        Helpers.SafeOpenServerUri(link.Url);
     }
 
     protected override void OnDataContextChanged(EventArgs e)


### PR DESCRIPTION
Servers can now provide privacy policy information via their info API. If provided, users will be prompted to accept the policy while being presented with a link to open it.

Accepted privacy policies are stored in the launcher's settings database. Servers can report changes in their privacy policy version, in which case the user will be re-prompted with a different message.

Fixes https://github.com/space-wizards/SS14.Launcher/issues/194