### PR TITLE
Replace some magic column sizing numbers with SharedSizeGroup

### DIFF
--- a/SS14.Launcher/Theme/Theme.xaml
+++ b/SS14.Launcher/Theme/Theme.xaml
@@ -65,20 +65,21 @@
     <Setter Property="FontSize" Value="20" />
   </Style>
 
-  <Style Selector="Rectangle.VerticalSeparator">
-    <Setter Property="Fill">
-      <SolidColorBrush Color="{DynamicResource ThemeListSeparatorColor}" />
-    </Setter>
-    <Setter Property="Width" Value="2" />
-    <Setter Property="Margin" Value="0 4" />
-  </Style>
-
-  <Style Selector="Border.VerticalSeparator">
+  <Style Selector="Border.GridCell">
     <Setter Property="BorderBrush">
       <SolidColorBrush Color="{DynamicResource ThemeListSeparatorColor}" />
     </Setter>
     <Setter Property="BorderThickness" Value="0,0,2,0" />
-    <Setter Property="Margin" Value="0 4" />
+    <Setter Property="Padding" Value="4 0" />
+    <Style Selector="^:nth-last-child(1)">
+      <!-- Disable divider line for the last column -->
+      <Setter Property="BorderThickness" Value="0" />
+    </Style>
+    <Style Selector="^ TextBlock">
+      <Setter Property="VerticalAlignment" Value="Center" />
+      <Setter Property="TextAlignment" Value="Center" />
+      <Setter Property="HorizontalAlignment" Value="Center" />
+    </Style>
   </Style>
 
   <Style Selector="ScrollBar">

--- a/SS14.Launcher/Theme/Theme.xaml
+++ b/SS14.Launcher/Theme/Theme.xaml
@@ -73,6 +73,14 @@
     <Setter Property="Margin" Value="0 4" />
   </Style>
 
+  <Style Selector="Border.VerticalSeparator">
+    <Setter Property="BorderBrush">
+      <SolidColorBrush Color="{DynamicResource ThemeListSeparatorColor}" />
+    </Setter>
+    <Setter Property="BorderThickness" Value="0,0,2,0" />
+    <Setter Property="Margin" Value="0 4" />
+  </Style>
+
   <Style Selector="ScrollBar">
     <Setter Property="Margin" Value="4 0 0 0" />
   </Style>

--- a/SS14.Launcher/Views/MainWindowTabs/HomePageView.xaml
+++ b/SS14.Launcher/Views/MainWindowTabs/HomePageView.xaml
@@ -38,11 +38,12 @@
       </Panel.Background>
       <ScrollViewer MinHeight="150" HorizontalScrollBarVisibility="Disabled">
         <Panel>
-          <DockPanel IsVisible="{Binding !FavoritesEmpty}" LastChildFill="True">
+          <DockPanel IsVisible="{Binding !FavoritesEmpty}" LastChildFill="True" Grid.IsSharedSizeScope="True">
             <StackPanel DockPanel.Dock="Bottom" IsVisible="True">
             <Button Content="{loc:Loc tab-home-go-to-servers-tab}" Command="{Binding MainWindowViewModel.SelectTabServers}"
                     HorizontalAlignment="Center" />
             </StackPanel>
+
             <ItemsControl ItemsSource="{Binding Favorites}"
                           Classes="ServerList" />
           </DockPanel>

--- a/SS14.Launcher/Views/MainWindowTabs/ServerEntryView.xaml
+++ b/SS14.Launcher/Views/MainWindowTabs/ServerEntryView.xaml
@@ -15,16 +15,27 @@
   <Panel>
     <Expander Name="Expando" Classes="NoPad" IsExpanded="{Binding IsExpanded}">
       <Expander.Header>
-        <DockPanel>
-          <Button IsEnabled="{Binding IsOnline}" DockPanel.Dock="Right" Content="{loc:Loc server-entry-connect}"
+        <Grid>
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" /> <!-- Server Name -->
+            <ColumnDefinition SharedSizeGroup="A" MinWidth="80" Width="Auto" /> <!-- Player Count -->
+            <ColumnDefinition SharedSizeGroup="B" Width="Auto" /> <!-- Connect Button -->
+          </Grid.ColumnDefinitions>
+
+          <Button Grid.Column="2" IsEnabled="{Binding IsOnline}" DockPanel.Dock="Right"
+                  Content="{loc:Loc server-entry-connect}"
                   Command="{Binding ConnectPressed}" />
-          <TextBlock DockPanel.Dock="Right" VerticalAlignment="Center"
-                     TextAlignment="Center" Text="{Binding ServerStatusString}"
-                     MinWidth="80"
-                     Margin="10, 0" />
-          <Rectangle DockPanel.Dock="Right" Classes="VerticalSeparator" />
-          <TextBlock VerticalAlignment="Center" Text="{Binding Name}" TextTrimming="CharacterEllipsis"/>
-        </DockPanel>
+
+
+          <TextBlock Grid.Column="1" DockPanel.Dock="Right" VerticalAlignment="Center"
+                     TextAlignment="Center" Text="{Binding ServerStatusString}" />
+
+          <Border Grid.Column="0" Classes="VerticalSeparator">
+            <TextBlock Grid.Column="0" VerticalAlignment="Center" Text="{Binding Name}"
+                       TextTrimming="CharacterEllipsis" />
+          </Border>
+
+        </Grid>
       </Expander.Header>
       <DockPanel Margin="4">
         <TextBlock DockPanel.Dock="Top"

--- a/SS14.Launcher/Views/MainWindowTabs/ServerEntryView.xaml
+++ b/SS14.Launcher/Views/MainWindowTabs/ServerEntryView.xaml
@@ -18,23 +18,24 @@
         <Grid>
           <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*" /> <!-- Server Name -->
-            <ColumnDefinition SharedSizeGroup="A" MinWidth="80" Width="Auto" /> <!-- Player Count -->
-            <ColumnDefinition SharedSizeGroup="B" Width="Auto" /> <!-- Connect Button -->
+            <ColumnDefinition SharedSizeGroup="StatusCol" MinWidth="80" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="ConnectCol" Width="Auto" />
           </Grid.ColumnDefinitions>
 
-          <Button Grid.Column="2" IsEnabled="{Binding IsOnline}" DockPanel.Dock="Right"
-                  Content="{loc:Loc server-entry-connect}"
-                  Command="{Binding ConnectPressed}" />
-
-
-          <TextBlock Grid.Column="1" DockPanel.Dock="Right" VerticalAlignment="Center"
-                     TextAlignment="Center" Text="{Binding ServerStatusString}" />
-
-          <Border Grid.Column="0" Classes="VerticalSeparator">
-            <TextBlock Grid.Column="0" VerticalAlignment="Center" Text="{Binding Name}"
-                       TextTrimming="CharacterEllipsis" />
+          <Border Grid.Column="0" Classes="GridCell">
+            <TextBlock VerticalAlignment="Center" Text="{Binding Name}" TextTrimming="CharacterEllipsis" HorizontalAlignment="Left" />
           </Border>
 
+          <Border Grid.Column="1" Classes="GridCell">
+            <TextBlock DockPanel.Dock="Right"
+                       Margin="10 0"
+                       Text="{Binding ServerStatusString}" />
+          </Border>
+
+          <Border Grid.Column="2" Classes="GridCell">
+            <Button IsEnabled="{Binding IsOnline}" DockPanel.Dock="Right" Content="{loc:Loc server-entry-connect}"
+                    Command="{Binding ConnectPressed}" />
+          </Border>
         </Grid>
       </Expander.Header>
       <DockPanel Margin="4">

--- a/SS14.Launcher/Views/MainWindowTabs/ServerListTabView.xaml
+++ b/SS14.Launcher/Views/MainWindowTabs/ServerListTabView.xaml
@@ -27,15 +27,18 @@
 
     <Grid>
       <!-- Main server list table -->
-      <DockPanel ZIndex="-1">
-        <DockPanel DockPanel.Dock="Top" Margin="4, 0, 4, 2">
-          <!--TODO: These measurements are just golfed based on approximations of where the sections *probably* are, and assumes a scroll bar is present. This might prove a bit wonky with localization and excessive screen sizes. It'd be ideal if this header section could dynamically adapt to the section sizes in the server list.-->
-          <Control DockPanel.Dock="Right" MinWidth="105" />
-          <Rectangle DockPanel.Dock="Right" Classes="VerticalSeparator"/>
-          <TextBlock DockPanel.Dock="Right" Text="{loc:Loc tab-servers-table-players}" Classes="SubText" TextAlignment="Center" MinWidth="80" Margin="10 0"/>
-          <Rectangle DockPanel.Dock="Right" Classes="VerticalSeparator" />
-          <TextBlock Text="{loc:Loc tab-servers-table-name}" Classes="SubText"/>
-        </DockPanel>
+      <DockPanel ZIndex="-1" Grid.IsSharedSizeScope="True">
+        <Grid DockPanel.Dock="Top" Margin="14 0 22 0">
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" /> <!-- Server Name -->
+            <ColumnDefinition SharedSizeGroup="A" MinWidth="80" /> <!-- Player Count -->
+            <ColumnDefinition SharedSizeGroup="B" /> <!-- Connect Button -->
+          </Grid.ColumnDefinitions>
+
+          <TextBlock Grid.Column="0" Text="{loc:Loc tab-servers-table-name}" Classes="SubText" />
+          <TextBlock Grid.Column="1" Text="{loc:Loc tab-servers-table-players}" Classes="SubText" TextAlignment="Center" />
+          <TextBlock Grid.Column="2" Text="" Classes="SubText" />
+        </Grid>
 
         <Panel DockPanel.Dock="Top" Classes="ScrollViewerSep" />
 
@@ -45,10 +48,10 @@
           </Panel.Background>
           <ScrollViewer MinHeight="150" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Visible">
             <Grid RowDefinitions="Auto,Auto,Auto">
-              <ItemsControl Grid.Row="0" ItemsSource="{Binding SearchedServers}" Classes="ServerList" />
-              <TextBlock Grid.Row="1" IsVisible="{Binding ListTextVisible}" TextAlignment="Center" VerticalAlignment="Center"
+              <ItemsControl Grid.Column="0" Grid.Row="0" ItemsSource="{Binding SearchedServers}" Classes="ServerList" />
+              <TextBlock Grid.Column="0" Grid.Row="1" IsVisible="{Binding ListTextVisible}" TextAlignment="Center" VerticalAlignment="Center"
                          Text="{Binding ListText}" />
-              <Viewbox Grid.Row="2" IsVisible="{Binding SpinnerVisible}" Classes="DungSpinnerBox">
+              <Viewbox Grid.Column="0" Grid.Row="2" IsVisible="{Binding SpinnerVisible}" Classes="DungSpinnerBox">
                 <views:DungSpinner />
               </Viewbox>
             </Grid>

--- a/SS14.Launcher/Views/MainWindowTabs/ServerListTabView.xaml
+++ b/SS14.Launcher/Views/MainWindowTabs/ServerListTabView.xaml
@@ -15,10 +15,12 @@
   <DockPanel LastChildFill="True">
 
     <DockPanel DockPanel.Dock="Bottom" Margin="4 4 4 0">
-      <Button DockPanel.Dock="Right" Content="{loc:Loc tab-servers-refresh}" Command="{Binding RefreshPressed}"  Classes="OpenLeft" />
+      <Button DockPanel.Dock="Right" Content="{loc:Loc tab-servers-refresh}" Command="{Binding RefreshPressed}"
+              Classes="OpenLeft" />
       <ToggleButton DockPanel.Dock="Right" IsChecked="{Binding FiltersVisible}" Classes="OpenRight"
                     Content="{Binding Filters.FiltersText}" />
-      <TextBox DockPanel.Dock="Right" Text="{Binding SearchString, Mode=TwoWay}" Watermark="{loc:Loc tab-servers-search-watermark}"
+      <TextBox DockPanel.Dock="Right" Text="{Binding SearchString, Mode=TwoWay}"
+               Watermark="{loc:Loc tab-servers-search-watermark}"
                UseFloatingWatermark="False"
                Margin="0 0 8 0" />
     </DockPanel>
@@ -28,16 +30,22 @@
     <Grid>
       <!-- Main server list table -->
       <DockPanel ZIndex="-1" Grid.IsSharedSizeScope="True">
-        <Grid DockPanel.Dock="Top" Margin="14 0 22 0">
+        <Grid DockPanel.Dock="Top" Margin="24 0 24 0">
           <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*" /> <!-- Server Name -->
-            <ColumnDefinition SharedSizeGroup="A" MinWidth="80" /> <!-- Player Count -->
-            <ColumnDefinition SharedSizeGroup="B" /> <!-- Connect Button -->
+            <ColumnDefinition SharedSizeGroup="StatusCol" MinWidth="80" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="ConnectCol" Width="Auto" />
           </Grid.ColumnDefinitions>
 
-          <TextBlock Grid.Column="0" Text="{loc:Loc tab-servers-table-name}" Classes="SubText" />
-          <TextBlock Grid.Column="1" Text="{loc:Loc tab-servers-table-players}" Classes="SubText" TextAlignment="Center" />
-          <TextBlock Grid.Column="2" Text="" Classes="SubText" />
+          <Border Grid.Column="0" Classes="GridCell">
+            <TextBlock Text="{loc:Loc tab-servers-table-name}" Classes="SubText" HorizontalAlignment="Left" />
+          </Border>
+          <Border Grid.Column="1" Classes="GridCell">
+            <TextBlock Text="{loc:Loc tab-servers-table-players}" Classes="SubText" />
+          </Border>
+          <Border Grid.Column="2" Classes="GridCell">
+            <TextBlock Text="" Classes="SubText" />
+          </Border>
         </Grid>
 
         <Panel DockPanel.Dock="Top" Classes="ScrollViewerSep" />
@@ -49,7 +57,8 @@
           <ScrollViewer MinHeight="150" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Visible">
             <Grid RowDefinitions="Auto,Auto,Auto">
               <ItemsControl Grid.Column="0" Grid.Row="0" ItemsSource="{Binding SearchedServers}" Classes="ServerList" />
-              <TextBlock Grid.Column="0" Grid.Row="1" IsVisible="{Binding ListTextVisible}" TextAlignment="Center" VerticalAlignment="Center"
+              <TextBlock Grid.Column="0" Grid.Row="1" IsVisible="{Binding ListTextVisible}" TextAlignment="Center"
+                         VerticalAlignment="Center"
                          Text="{Binding ListText}" />
               <Viewbox Grid.Column="0" Grid.Row="2" IsVisible="{Binding SpinnerVisible}" Classes="DungSpinnerBox">
                 <views:DungSpinner />
@@ -61,8 +70,8 @@
       </DockPanel>
 
       <!-- Filters dialog -->
-      <Border Height="175" VerticalAlignment="Bottom"  IsVisible="{Binding FiltersVisible}" BoxShadow="0 -2 4 Black">
-        <Panel Background="{DynamicResource ThemeBackgroundBrush}" >
+      <Border Height="175" VerticalAlignment="Bottom" IsVisible="{Binding FiltersVisible}" BoxShadow="0 -2 4 Black">
+        <Panel Background="{DynamicResource ThemeBackgroundBrush}">
           <mainWindowTabs1:ServerListFiltersView DataContext="{Binding Filters}" />
         </Panel>
       </Border>


### PR DESCRIPTION
This should fix column layouts for other languages, and make it easier to add new columns.

Before/after for French (see column headers):
<img width="912" alt="Screenshot 2025-02-19 at 17 02 54" src="https://github.com/user-attachments/assets/10fd09db-560d-4b4f-9b60-d2873c516555" />
<img width="912" alt="Screenshot 2025-02-20 at 15 28 47" src="https://github.com/user-attachments/assets/2f644aea-98d5-42d5-b21b-ce20e45513b4" />


Before/after for English:
<img width="912" alt="Screenshot 2025-02-19 at 17 03 04" src="https://github.com/user-attachments/assets/7391ed7f-d198-408c-89bc-d27b582d9be2" />
<img width="912" alt="Screenshot 2025-02-20 at 15 28 37" src="https://github.com/user-attachments/assets/b6aef538-3c07-4f4e-909b-16a27534d136" />
