### PR TITLE
Fix a crash which would occur if the round start time was in the future.

### DIFF
--- a/SS14.Launcher/Controls/TimerTextCell.xaml.cs
+++ b/SS14.Launcher/Controls/TimerTextCell.xaml.cs
@@ -75,7 +75,7 @@ public class TimerTextCell : TemplatedControl
         if (_attached && Value is { } dt)
         {
             var ts = DateTime.UtcNow.Subtract(dt);
-            _timer = DispatcherTimer.RunOnce(UpdateText, TimeSpan.FromSeconds(ts.Seconds));
+            _timer = DispatcherTimer.RunOnce(UpdateText, TimeSpan.FromSeconds((ts.Seconds >= 0 ? ts.Seconds : 60)));
         }
     }
 


### PR DESCRIPTION
This would cause DispatcherTimer.RunOnce to throw an exception as it expects a positive TimeSpan.
