### PR TITLE
Make refresh button position consistent

### DIFF
--- a/SS14.Launcher/Views/MainWindowTabs/HomePageView.xaml
+++ b/SS14.Launcher/Views/MainWindowTabs/HomePageView.xaml
@@ -13,22 +13,22 @@
   </Design.DataContext>
 
   <DockPanel>
-    <!-- Account info -->
-
-    <!-- Favorites -->
+    <!-- Header controls -->
     <DockPanel DockPanel.Dock="Top" LastChildFill="False" Margin="4, 0, 4, 2">
       <TextBlock DockPanel.Dock="Left" Text="{loc:Loc tab-home-favorite-servers}" Classes="NanoHeadingMedium" />
-      <Button DockPanel.Dock="Right" Content="{loc:Loc tab-home-add-favorite}" Classes="OpenLeft"
+      <Button DockPanel.Dock="Right" Content="{loc:Loc tab-home-add-favorite}"
               Command="{Binding AddFavoritePressed}" />
-      <Button DockPanel.Dock="Right" Content="{loc:Loc tab-home-refresh}" Classes="OpenRight"
-              Command="{Binding RefreshPressed}" />
     </DockPanel>
 
-    <DockPanel DockPanel.Dock="Bottom" LastChildFill="False" Margin="0, 5, 5, 1">
-      <Button DockPanel.Dock="Right" HorizontalAlignment="Right" Classes="OpenLeft"
+    <!-- Footer controls -->
+    <DockPanel DockPanel.Dock="Bottom" LastChildFill="False" Margin="4 4 4 0" Height="32">
+      <Button DockPanel.Dock="Right" Content="{loc:Loc tab-home-refresh}"
+              Command="{Binding RefreshPressed}" />
+
+      <Button DockPanel.Dock="Left" Classes="OpenRight"
               Content="{loc:Loc tab-home-direct-connect}"
               Command="{Binding DirectConnectPressed}" />
-      <Button DockPanel.Dock="Right" HorizontalAlignment="Right" Classes="OpenRight"
+      <Button DockPanel.Dock="Left" Classes="OpenLeft"
               Content="{loc:Loc tab-home-run-content-bundle}"
               Click="OpenReplayClicked" />
     </DockPanel>

--- a/SS14.Launcher/Views/MainWindowTabs/ServerListTabView.xaml
+++ b/SS14.Launcher/Views/MainWindowTabs/ServerListTabView.xaml
@@ -18,7 +18,7 @@
   </UserControl.Styles>
 
   <DockPanel LastChildFill="True">
-    <DockPanel DockPanel.Dock="Bottom" Margin="4 4 4 0">
+    <DockPanel DockPanel.Dock="Bottom" Margin="4 4 4 0" Height="32">
       <Button DockPanel.Dock="Right" Content="{loc:Loc tab-servers-refresh}" Command="{Binding RefreshPressed}"
               Classes="OpenLeft" />
       <ToggleButton DockPanel.Dock="Right" IsChecked="{Binding FiltersVisible}" Classes="OpenRight"


### PR DESCRIPTION
Currently the two server list tabs share only one button (Refresh) and it’s in a different place on each tab which makes it frustrating to find each time.

This changes the layout of the home tab buttons, putting the Refresh button in the bottom right to keep it its location consistent across both tabs.

<img width="912" alt="Screenshot 2025-03-20 at 14 31 48" src="https://github.com/user-attachments/assets/a77316f5-29c6-4bfc-ab2e-e169cfe8309d" />

