### PR TITLE
Fix post-round lobby status indicator

### DIFF
--- a/SS14.Launcher/Views/MainWindowTabs/ServerEntryView.xaml
+++ b/SS14.Launcher/Views/MainWindowTabs/ServerEntryView.xaml
@@ -35,8 +35,8 @@
 
           <Border Grid.Column="1" Classes="GridCell" IsVisible="{Binding HaveData}">
             <Panel>
-              <controls:TimerTextCell Value="{Binding RoundStartTime}" IsVisible="{Binding RoundStartTime,Converter={x:Static ObjectConverters.IsNotNull}}" />
-              <TextBlock Text="{Binding RoundStatusString}" HorizontalAlignment="Right" IsVisible="{Binding RoundStartTime,Converter={x:Static ObjectConverters.IsNull}}" />
+              <controls:TimerTextCell Value="{Binding RoundStartTime}" IsVisible="{Binding RoundStatusString,Converter={x:Static StringConverters.IsNullOrEmpty}}" />
+              <TextBlock Text="{Binding RoundStatusString}" HorizontalAlignment="Right" IsVisible="{Binding RoundStatusString,Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
             </Panel>
           </Border>
 


### PR DESCRIPTION
During the post-round lobby state the round timer is still present, so the round status must be checked.
