### PR TITLE
Add Proxy support for hub/auth/build downloads

### DIFF
--- a/SS14.Launcher/HappyEyeballsHttp.cs
+++ b/SS14.Launcher/HappyEyeballsHttp.cs
@@ -51,7 +51,7 @@ public static class HappyEyeballsHttp
         if (!String.IsNullOrEmpty(proxyUrl)){ //Note: I'm VERY new to writing c#. This is heavily copied from koksnull's work in https://github.com/space-wizards/SS14.Launcher/pull/144 . I've just made some adjustments to make it work for the modern versions of .net 
             //I'm unsure of how to go about this, but having some way to sanity check the proxy before activating it (i.e. a test ping) would be great.
             Uri proxyURI = new Uri(proxyUrl.Trim('"'));
-            WebProxy clientProxy = new WebProxy(proxyUrl.Trim('"'));
+            WebProxy clientProxy = new WebProxy(proxyUrl.Trim('"')); //No clue why .trim('"') is required. C# jank? Doesn't work otherwise.
             if (!string.IsNullOrWhiteSpace(proxyURI.UserInfo)){
                 string[] credentials = proxyURI.UserInfo.Split(new[] { ':' });
                 if (credentials.Length > 1){

--- a/SS14.Launcher/HappyEyeballsHttp.cs
+++ b/SS14.Launcher/HappyEyeballsHttp.cs
@@ -9,7 +9,6 @@ using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Serilog;
-
 namespace SS14.Launcher;
 
 public static class HappyEyeballsHttp
@@ -39,8 +38,9 @@ public static class HappyEyeballsHttp
     // * Look I wanted to keep this simple OK?
     //   We don't do any fancy shit like statefulness or incremental sorting
     //   or incremental DNS updates who cares about that.
-    public static HttpClient CreateHttpClient(bool autoRedirect = true)
+    public static HttpClient CreateHttpClient(bool autoRedirect = true, string proxyUrl = "")
     {
+        // Log.Verbose("PROXY_URL: ", proxyUrl);
         var handler = new SocketsHttpHandler
         {
             ConnectCallback = OnConnect,
@@ -48,6 +48,20 @@ public static class HappyEyeballsHttp
             AllowAutoRedirect = autoRedirect,
             // PooledConnectionLifetime = TimeSpan.FromSeconds(1)
         };
+        if (!String.IsNullOrEmpty(proxyUrl)){ //Note: I'm VERY new to writing c#. This is heavily copied from koksnull's work in https://github.com/space-wizards/SS14.Launcher/pull/144 . I've just made some adjustments to make it work for the modern versions of .net 
+            //I'm unsure of how to go about this, but having some way to sanity check the proxy before activating it (i.e. a test ping) would be great.
+            Uri proxyURI = new Uri(proxyUrl.Trim('"'));
+            WebProxy clientProxy = new WebProxy(proxyUrl.Trim('"'));
+            if (!string.IsNullOrWhiteSpace(proxyURI.UserInfo)){
+                string[] credentials = proxyURI.UserInfo.Split(new[] { ':' });
+                if (credentials.Length > 1){
+                    NetworkCredential cred = new NetworkCredential(userName: credentials[0], password: credentials[1]);
+                    clientProxy.Credentials = cred;
+                }
+            }
+            handler.UseProxy = true;
+            handler.Proxy = clientProxy;
+        }
 
         return new HttpClient(handler);
     }

--- a/SS14.Launcher/HttpSelfTest.cs
+++ b/SS14.Launcher/HttpSelfTest.cs
@@ -80,7 +80,7 @@ internal static class HttpSelfTest
 
     private static async Task TestHappyEyeballsHttp(int id, string url)
     {
-        using var client = HappyEyeballsHttp.CreateHttpClient(false);
+        using var client = HappyEyeballsHttp.CreateHttpClient(false); //Note: It may be worth refactoring this to also allow the http checks to be done via proxy. Afaik it doesn't cause issues, and would require giving it a ref to DataManager but it could certainly be done.
 
         using var resp = await client.GetAsync(url);
 

--- a/SS14.Launcher/Models/Data/CVars.cs
+++ b/SS14.Launcher/Models/Data/CVars.cs
@@ -114,6 +114,16 @@ public static class CVars
     /// Language the user selected. Null means it should be automatically selected based on system language.
     /// </summary>
     public static readonly CVarDef<string?> Language = CVarDef.Create<string?>("Language", null);
+
+    /// <summary>
+    /// Weather the proxy is enabled for HappyEyeballsHttp connections (ie auth server/build server/hub connections, not game server connections)
+    /// </summary>
+    public static readonly CVarDef<bool> ProxyEnable = CVarDef.Create("ProxyEnable", false);
+
+    /// <summary>
+    /// Url for proxy connections.
+    /// </summary>
+    public static readonly CVarDef<string> ProxyURL = CVarDef.Create("ProxyURL", "");
 }
 
 /// <summary>

--- a/SS14.Launcher/Program.cs
+++ b/SS14.Launcher/Program.cs
@@ -213,7 +213,7 @@ internal static class Program
     {
         var locator = Locator.CurrentMutable;
 
-        var http = HappyEyeballsHttp.CreateHttpClient();
+        var http = (cfg.GetCVar(CVars.ProxyEnable)) ? HappyEyeballsHttp.CreateHttpClient(proxyUrl: cfg.GetCVar(CVars.ProxyURL)) : HappyEyeballsHttp.CreateHttpClient(); //Ternary for creating connection with or without proxy 
         http.DefaultRequestHeaders.UserAgent.Add(
             new ProductInfoHeaderValue(LauncherVersion.Name, LauncherVersion.Version?.ToString()));
         http.DefaultRequestHeaders.Add("SS14-Launcher-Fingerprint", cfg.Fingerprint.ToString());

--- a/SS14.Launcher/ViewModels/MainWindowTabs/OptionsTabViewModel.cs
+++ b/SS14.Launcher/ViewModels/MainWindowTabs/OptionsTabViewModel.cs
@@ -100,6 +100,26 @@ public class OptionsTabViewModel : MainWindowTabViewModel
         _engineManager.ClearAllEngines();
     }
 
+    public bool ProxyEnable
+    {
+        get => Cfg.GetCVar(CVars.ProxyEnable);
+        set
+        {
+            Cfg.SetCVar(CVars.ProxyEnable, value);
+            Cfg.CommitConfig();
+        }
+    }
+
+    public string ProxyURL
+    {
+        get => Cfg.GetCVar(CVars.ProxyURL);
+        set
+        {
+            Cfg.SetCVar(CVars.ProxyURL, value);
+            Cfg.CommitConfig();
+        }
+    }
+
     public void ClearServerContent()
     {
         _contentManager.ClearAll();

--- a/SS14.Launcher/Views/MainWindowTabs/OptionsTabView.xaml
+++ b/SS14.Launcher/Views/MainWindowTabs/OptionsTabView.xaml
@@ -65,7 +65,13 @@
         <TextBlock VerticalAlignment="Center" IsVisible="{Binding !HideDisableSigning}" TextWrapping="Wrap"
                    Text="{loc:Loc tab-options-disable-signing-desc}"
                    Margin="8" />
-
+        <Grid ColumnDefinitions="Auto,*">
+          <CheckBox VerticalAlignment="Center" Margin="4" IsChecked="{Binding ProxyEnable}">Enable proxy</CheckBox>
+          <TextBox Grid.Column="1" Watermark="http://example.com:80" Text="{Binding ProxyURL}" />
+        </Grid>
+        <TextBlock VerticalAlignment="Center" TextWrapping="Wrap"
+                  Text="Proxy information for connect to hub and auth center. (requires launcher restart)"
+                  Margin="8" />
         <Button Click="OpenHubSettings" Content="{loc:Loc tab-options-hub-settings}" Margin="4" HorizontalAlignment="Left" />
         <TextBlock VerticalAlignment="Center" TextWrapping="Wrap"
                    Text="{loc:Loc tab-options-hub-settings-desc}"


### PR DESCRIPTION
First off, this is HEAVILY based on koksnull's work in PR #144, with tweaks made to allow it to work w/modern libraries/main repo version. Note that I rarely if ever use C#, so expect to see some horrific code in here somewhere. I am fully open to any suggestions/changes. 

This adds proxy functionality to the hub (via happyeyeballshttp) allowing for proxied server discovery, build downloads, etc.
I've tested this on OSX with a socks5 ssh tunnel proxy, and if anyone has other proxies they can test it with please do. 

Known issues:
- Connecting to servers can cause an ssl error (as in the game instance itself does not use the proxy. Not sure if that can be fixed w/o changing every client build but idk, I work around it via a temp. tsocks proxy. Your mileage may vary, could be an osx thing.
- Should either be editable from the login menu, or reset upon failed connection. I'm not sure how to do either.
- Makes it impossible to join a LAN server w/o port forwarding it, as all traffic is directed through the proxy.

Bit of a mess, but this is my first time. Hopefully y'all can see what I can't so this can get merged. <3