### PR TITLE
Fix inexplicably different scrollbar behaviour

### DIFF
--- a/SS14.Launcher/Theme/ThemeServerList.axaml
+++ b/SS14.Launcher/Theme/ThemeServerList.axaml
@@ -74,7 +74,7 @@
               <SolidColorBrush Color="#1e1e22" />
             </Panel.Background>
             <ScrollViewer MinHeight="150" HorizontalScrollBarVisibility="Disabled"
-                          VerticalScrollBarVisibility="Visible">
+                          VerticalScrollBarVisibility="Auto">
               <DockPanel LastChildFill="True">
                 <StackPanel DockPanel.Dock="Bottom" IsVisible="True">
                   <ContentPresenter Content="{TemplateBinding Content}" HorizontalAlignment="Center" />


### PR DESCRIPTION
Restores the original behaviour of the scrollbar being hidden if the content does not need to scroll (despite no scrollbar properties being changed).