### PR TITLE
Esperanta Lanĉilo!

### DIFF
--- a/SS14.Launcher/Localization/LocalizationManager.cs
+++ b/SS14.Launcher/Localization/LocalizationManager.cs
@@ -42,6 +42,7 @@ public sealed class LocalizationManager
         new LanguageInfo("it"),
         new LanguageInfo("nb-NO"),
         new LanguageInfo("hu"),
+        new LanguageInfo("eo"),
     ];
 
     private const string FallbackCulture = "en";


### PR DESCRIPTION
La Esperanta traduko de la lanĉilo pretas por rostiĝi! (estu afabla ^^;)

<img width="662" height="297" alt="image" src="https://github.com/user-attachments/assets/e2d36d87-def4-474b-a025-ed50163f3d1a" />


This was finished at around 12:54 AM (EST) on July 11th, 2025. Weblate made an auto commit a few hours prior to this, so if weblate didn't make another Esperanto commit by the time this PR is merged, it may need to be manually updated in order for the translation to be properly included in the resulting launcher build.

The translation has not been peer-reviewed, so may need editing if SS14 ends up with more esperantists (if this does not happen then we will *make* it happen. this is a threat.)

But! This should more than suffice as a starting point for the Esperanto translation.