### PR TITLE
Allows round timers to gracefully surpass 24h

### DIFF
--- a/SS14.Launcher/Controls/TimerTextCell.xaml.cs
+++ b/SS14.Launcher/Controls/TimerTextCell.xaml.cs
@@ -88,7 +88,7 @@ public class TimerTextCell : TemplatedControl
     private string GetTimeStringSince(DateTime dateTime)
     {
         var ts = DateTime.UtcNow.Subtract(dateTime);
-        return _loc.GetString("server-entry-round-time", ("hours", ts.Hours),
+        return _loc.GetString("server-entry-round-time", ("hours", Math.Floor(ts.TotalHours)),
             ("mins", ts.Minutes.ToString().PadLeft(2, '0')));
     }
 }


### PR DESCRIPTION
We see u there, StarHorizon, with ur 26 hour long round times, of which the launcher only displays as 2h

(This PR swaps the use of `Hours` in the round timer display with a `Math.Floor(TotalHours)`, allowing round times longer than 24h to be properly displayed)

Before this change:
<img width="800" height="500" alt="image" src="https://github.com/user-attachments/assets/c8406b28-0af4-4245-9bcf-510a72c53e25" />

After this change:
<img width="800" height="500" alt="image" src="https://github.com/user-attachments/assets/c4e60b3c-f052-46c1-99e2-f9f42edeba39" />
