### PR TITLE
Fix a small typo in the intel degrade CPU warning at first start

### DIFF
--- a/SS14.Launcher/Assets/Locale/en-US/text.ftl
+++ b/SS14.Launcher/Assets/Locale/en-US/text.ftl
@@ -171,11 +171,11 @@ main-window-early-access-desc = Space Station 14 is still very much in alpha. We
 main-window-early-access-accept = Got it!
 main-window-intel-degrade-title = Intel 13th/14th Generation CPU detected.
 main-window-intel-degrade-desc =
-    The Intel 13th/14th generation CPUs are known to silently degrade permenently and die due to a microcode bug by Intel. We sadly can't tell if you are currently affected by this bug, so this warning appears for all users with these CPUs.
+    The Intel 13th/14th generation CPUs are known to silently degrade permanently and die due to a microcode bug by Intel. We sadly can't tell if you are currently affected by this bug, so this warning appears for all users with these CPUs.
 
     We STRONGLY encourage you to update your motherboard's BIOS to the latest version to ensure prevention of further damage. If you are having stability issues/failing to start the game, downclock your CPU to get it stable again and use your warranty to ask about getting it replaced.
 
-    We are not responsible to help with any issues that may arise from affected processors unless you took the precautions and are sure your CPU is stable. This message will not appear again after you accept it.
+    We are not responsible to help with any issues that may arise from affected processors, unless you took the precautions and are sure your CPU is stable. This message will not appear again after you accept it.
 main-window-intel-degrade-accept = I understand and have taken the necessary precautions.
 main-window-rosetta-title = You are running the game using Rosetta 2!
 main-window-rosetta-desc =


### PR DESCRIPTION
Nothing too crazy.

<img width="484" height="396" alt="image" src="https://github.com/user-attachments/assets/6a729f28-29b1-4c6c-90fa-8e601079cbbc" />
