### PR TITLE
Automaticaly capitalize language name in filters

### DIFF
--- a/SS14.Launcher/ViewModels/MainWindowTabs/ServerListFiltersViewModel.cs
+++ b/SS14.Launcher/ViewModels/MainWindowTabs/ServerListFiltersViewModel.cs
@@ -152,8 +152,7 @@ public sealed partial class ServerListFiltersViewModel : ObservableObject
                         continue;
                     }
 
-                    var name = culture.DisplayName;
-                    name = string.Concat(name[0].ToString().ToUpper(), name.AsSpan(1));
+                    var name = culture.TextInfo.ToTitleCase(culture.DisplayName);
                     var vm = new ServerFilterViewModel(name, name, filter, this);
                     filtersLanguage.Add(vm);
                 }

--- a/SS14.Launcher/ViewModels/MainWindowTabs/ServerListFiltersViewModel.cs
+++ b/SS14.Launcher/ViewModels/MainWindowTabs/ServerListFiltersViewModel.cs
@@ -153,6 +153,7 @@ public sealed partial class ServerListFiltersViewModel : ObservableObject
                     }
 
                     var name = culture.DisplayName;
+                    name = string.Concat(name[0].ToString().ToUpper(), name.AsSpan(1));
                     var vm = new ServerFilterViewModel(name, name, filter, this);
                     filtersLanguage.Add(vm);
                 }

--- a/SS14.Launcher/ViewModels/MainWindowTabs/ServerListFiltersViewModel.cs
+++ b/SS14.Launcher/ViewModels/MainWindowTabs/ServerListFiltersViewModel.cs
@@ -152,7 +152,7 @@ public sealed partial class ServerListFiltersViewModel : ObservableObject
                         continue;
                     }
 
-                    var name = culture.TextInfo.ToTitleCase(culture.DisplayName);
+                    var name = _loc.SystemCulture.TextInfo.ToTitleCase(culture.DisplayName);
                     var vm = new ServerFilterViewModel(name, name, filter, this);
                     filtersLanguage.Add(vm);
                 }


### PR DESCRIPTION
This is probably not the best way to do it, but lzk didn't give me any kind of proper review, so.
Right now launcher gets name of language directly from the culture name, and it looks fine, because in English things like that are capitalized, but, for example, russian filters looks very inconsistent.
This pr forces launcher capitalize filter name. Here is some media:
## Before:
<img width="781" height="246" alt="before" src="https://github.com/user-attachments/assets/b856f3c9-e5d1-49bc-9cbe-e81217370ab4" />

## After:
<img width="781" height="246" alt="after" src="https://github.com/user-attachments/assets/c70d3d47-71fd-4a0b-ab3a-280da6b6b6c3" />
