### PR TITLE
Fix audio libraries in nix package

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,5 +1,7 @@
 {
   lib,
+  stdenv,
+  config,
   buildDotnetModule,
   dotnetCorePackages,
   fetchFromGitHub,
@@ -16,7 +18,6 @@
   libXrandr,
   fontconfig,
   glew,
-  SDL2,
   glfw,
   glibc,
   libGL,
@@ -30,6 +31,15 @@
   zlib,
   glib,
   gdk-pixbuf,
+  alsa-lib,
+  libjack2,
+  pipewire,
+  libpulseaudio,
+  alsaSupport ? stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isAndroid,
+  jackSupport ? stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isAndroid,
+  pipewireSupport ? stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isAndroid,
+  pulseaudioSupport ?
+    config.pulseaudio or stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isAndroid,
   soundfont-fluid,
 
   # Path to set ROBUST_SOUNDFONT_OVERRIDE to, essentially the default soundfont used.
@@ -100,7 +110,6 @@ buildDotnetModule rec {
     libXrandr
 
     glfw
-    SDL2
     glibc
     libGL
     openal
@@ -111,7 +120,6 @@ buildDotnetModule rec {
   runtimeDeps = [
     # Required by the game.
     glfw
-    SDL2
     glibc
     libGL
     openal
@@ -139,7 +147,11 @@ buildDotnetModule rec {
     glew
 
     # TODO: Figure out dependencies for CEF support.
-  ];
+  ]
+  ++ lib.optional alsaSupport alsa-lib
+  ++ lib.optional jackSupport libjack2
+  ++ lib.optional pipewireSupport pipewire
+  ++ lib.optional pulseaudioSupport libpulseaudio;
 
   # ${soundfont-path} is escaped here:
   # https://github.com/NixOS/nixpkgs/blob/d29975d32b1dc7fe91d5cb275d20f8f8aba399ad/pkgs/build-support/setup-hooks/make-wrapper.sh#L126C35-L126C45


### PR DESCRIPTION
Currently fails to launch SS14 without audio libraries directly being included as they are not being provided to the bundled SDL2 library (which was vendored in [this](https://github.com/space-wizards/SS14.Launcher/commit/89c00db638eaa0ee2bcb34a4ee487ed026ad4983) commit updating `Robust.Natives`)