### PR TITLE
Clarify no engine/module for platform errors that the launcher is not responsible

### DIFF
--- a/SS14.Launcher/Assets/Locale/en-US/text.ftl
+++ b/SS14.Launcher/Assets/Locale/en-US/text.ftl
@@ -31,7 +31,7 @@ connecting-status-update-error =
     If you are still having issues, first try contacting the server you are attempting to join before asking for support on the Official Space Station 14 Discord or Forums.
 
     Technical error: { $err }
-connecting-status-update-error-no-engine-for-platform = This server is using a older game engine version that does not support your current platform. Please try another server or inform the server staff about this and try again later.
+connecting-status-update-error-no-engine-for-platform = This server is using an older game engine version that does not support your current platform. Please try another server or inform the server staff about this and try again later.
 connecting-status-update-error-no-module-for-platform = This server requires additional functionality that is not yet supported on your current platform. Please try another server or inform the server staff about this and try again later.
 connecting-status-update-error-unknown = Unknown
 connecting-status-updating = Updating: { $status }

--- a/SS14.Launcher/Assets/Locale/en-US/text.ftl
+++ b/SS14.Launcher/Assets/Locale/en-US/text.ftl
@@ -31,8 +31,8 @@ connecting-status-update-error =
     If you are still having issues, first try contacting the server you are attempting to join before asking for support on the Official Space Station 14 Discord or Forums.
 
     Technical error: { $err }
-connecting-status-update-error-no-engine-for-platform = This game is using an older version that does not support your current platform. Please try another server or try again later.
-connecting-status-update-error-no-module-for-platform = This game requires additional functionality that is not yet supported on your current platform. Please try another server or try again later.
+connecting-status-update-error-no-engine-for-platform = This server is using a game engine version that does not support your current platform. Please try another server or inform the server staff about this and try again later.
+connecting-status-update-error-no-module-for-platform = This server requires additional functionality that is not yet supported on your current platform. Please try another server or inform the server staff about this and try again later.
 connecting-status-update-error-unknown = Unknown
 connecting-status-updating = Updating: { $status }
 connecting-status-connecting = Fetching connection info from server…

--- a/SS14.Launcher/Assets/Locale/en-US/text.ftl
+++ b/SS14.Launcher/Assets/Locale/en-US/text.ftl
@@ -31,7 +31,7 @@ connecting-status-update-error =
     If you are still having issues, first try contacting the server you are attempting to join before asking for support on the Official Space Station 14 Discord or Forums.
 
     Technical error: { $err }
-connecting-status-update-error-no-engine-for-platform = This server is using a game engine version that does not support your current platform. Please try another server or inform the server staff about this and try again later.
+connecting-status-update-error-no-engine-for-platform = This server is using a older game engine version that does not support your current platform. Please try another server or inform the server staff about this and try again later.
 connecting-status-update-error-no-module-for-platform = This server requires additional functionality that is not yet supported on your current platform. Please try another server or inform the server staff about this and try again later.
 connecting-status-update-error-unknown = Unknown
 connecting-status-updating = Updating: { $status }


### PR DESCRIPTION
Using the word game is confusing, so it's switched for server.

Instructions now tell the player to inform the server they are attempting to join instead of the official ss14 server.