### PR TITLE
Command line argument to change robust url

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,6 +30,7 @@
     <PackageVersion Include="Serilog" Version="2.12.0"/>
     <PackageVersion Include="Serilog.Sinks.Console" Version="4.1.0"/>
     <PackageVersion Include="Serilog.Sinks.File" Version="5.0.0"/>
+    <PackageVersion Include="System.CommandLine" Version="2.0.0-rc.2.25502.107"/>
     <PackageVersion Include="YamlDotNet" Version="13.0.2"/>
     <PackageVersion Include="TerraFX.Interop.Windows" Version="10.0.26100.2"/>
     <PackageVersion Include="Mono.Posix.NETStandard" Version="1.0.0"/>

--- a/SS14.Launcher/SS14.Launcher.csproj
+++ b/SS14.Launcher/SS14.Launcher.csproj
@@ -57,6 +57,7 @@
     <PackageReference Include="Serilog" />
     <PackageReference Include="Serilog.Sinks.Console" />
     <PackageReference Include="Serilog.Sinks.File" />
+    <PackageReference Include="System.CommandLine" />
     <PackageReference Include="YamlDotNet" />
     <PackageReference Include="TerraFX.Interop.Windows" />
     <PackageReference Include="NSec.Cryptography" />


### PR DESCRIPTION
## Problem desc.

We noticed that some of the clients, in an unfortunate combination of circumstances, due to the work of the Russian executive organization RKN, which blocks access to IP addresses and domains at the request of government agencies, that some of the clients cannot play through the official client due to problems with access to official domains that lead to BunnyCDN by type robust.cdn. In the logs, you can see how the game starts a query and can't get rsponse from robust.cdn.

```
[17:32:41 VRB] Successfully connected to https://hub.spacestation14.com/api/servers
[17:32:41 VRB] Successfully connected Unspecified/launcher-data.cdn.spacestation14.com:443 to address: 138.199.24.219
Failed to call portal: GDBus.Error:org.freedesktop.DBus.Error.ServiceUnknown: The name org.freedesktop.portal.Desktop was not provided by any .service files
[17:32:54 DBG] Checking to see if we already have version for fork SS220ReleaseStation/541c91bd9773818d50b04136915f61d177976967 ZipHash: 034D364D89528B4AD2907B1DC9DB7C91828190EBD76E8F76FA43B2C175393B13 ManifestHash: 4B7285877A1F9537AABF1FAAA33B35B22E02EE5F63B1AB0BD406F4506D407FC2
[17:32:54 DBG] Found matching version: 8
[17:32:54 DBG] Checking to cull old content versions...
[17:32:54 DBG] Loading manifest from SS14.Launcher.Utility.UrlFallbackSet...
[17:32:54 VRB] Waiting on ConnectionAttemptDelay
[17:32:55 VRB] Trying IP 2400:52e0:1500::1272:1 for happy eyeballs [0]
[17:32:55 VRB] Happy Eyeballs to 2400:52e0:1500::1272:1 [0] failed
[17:32:55 VRB] Waiting on ConnectionAttemptDelay
[17:32:55 VRB] Trying IP 138.199.46.65 for happy eyeballs [1]
[17:32:55 VRB] Successfully connected Unspecified/robust-builds.cdn.spacestation14.com:443 to address: 138.199.46.65
[17:32:55 VRB] Successfully connected to https://robust-builds.cdn.spacestation14.com/manifest.json
[17:36:25 INF] Cancelled connect
System.Threading.Tasks.TaskCanceledException: The operation was canceled.
 ---> System.IO.IOException: Unable to read data from the transport connection: Operation canceled.
 ---> System.Net.Sockets.SocketException (125): Operation canceled
   --- End of inner exception stack trace ---
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Net.Security.SslStream.EnsureFullTlsFrameAsync[TIOAdapter](CancellationToken cancellationToken, Int32 estimatedSize)
   at System.Runtime.CompilerServices.PoolingAsyncValueTaskMethodBuilder`1.StateMachineBox`1.System.Threading.Tasks.Sources.IValueTaskSource<TResult>.GetResult(Int16 token)
   at System.Net.Security.SslStream.ReadAsyncInternal[TIOAdapter](Memory`1 buffer, CancellationToken cancellationToken)
   at System.Runtime.CompilerServices.PoolingAsyncValueTaskMethodBuilder`1.StateMachineBox`1.System.Threading.Tasks.Sources.IValueTaskSource<TResult>.GetResult(Int16 token)
   at System.Net.Http.HttpConnection.FillAsync(Boolean async)
   at System.Net.Http.HttpConnection.ChunkedEncodingReadStream.ReadAsyncCore(Memory`1 buffer, CancellationToken cancellationToken)
   --- End of inner exception stack trace ---
   at System.Net.Http.HttpConnection.ChunkedEncodingReadStream.ReadAsyncCore(Memory`1 buffer, CancellationToken cancellationToken)
   at System.IO.Compression.BrotliStream.<ReadAsync>g__Core|26_0(Memory`1 buffer, CancellationToken cancellationToken)
   at System.Text.Json.Serialization.ReadBufferState.ReadFromStreamAsync(Stream utf8Json, CancellationToken cancellationToken, Boolean fillBuffer)
   at System.Text.Json.Serialization.Metadata.JsonTypeInfo`1.DeserializeAsync(Stream utf8Json, CancellationToken cancellationToken)
   at System.Net.Http.Json.HttpContentJsonExtensions.ReadFromJsonAsyncCore[T](HttpContent content, JsonSerializerOptions options, CancellationToken cancellationToken)
   at SS14.Launcher.Utility.UrlFallbackSet.GetFromJsonAsync[T](HttpClient client, CancellationToken cancel) in /run/build/space-station-14-launcher/SS14.Launcher/Utility/UrlFallbackSet.cs:line 43
   at SS14.Launcher.Models.EngineManager.EngineManagerDynamic.UpdateBuildManifest(CancellationToken cancel) in /run/build/space-station-14-launcher/SS14.Launcher/Models/EngineManager/EngineManagerDynamic.Manifest.cs:line 72
   at SS14.Launcher.Models.EngineManager.EngineManagerDynamic.GetVersionInfoCore(String version, Boolean followRedirects, CancellationToken cancel) in /run/build/space-station-14-launcher/SS14.Launcher/Models/EngineManager/EngineManagerDynamic.Manifest.cs:line 62
   at SS14.Launcher.Models.EngineManager.EngineManagerDynamic.GetVersionInfo(String version, Boolean followRedirects, CancellationToken cancel) in /run/build/space-station-14-launcher/SS14.Launcher/Models/EngineManager/EngineManagerDynamic.Manifest.cs:line 40
   at SS14.Launcher.Models.EngineManager.EngineManagerDynamic.DownloadEngineIfNecessary(String engineVersion, DownloadProgressCallback progress, CancellationToken cancel) in /run/build/space-station-14-launcher/SS14.Launcher/Models/EngineManager/EngineManagerDynamic.cs:line 88
   at SS14.Launcher.Models.Updater.InstallEngineVersionIfMissing(String engineVer, CancellationToken cancel) in /run/build/space-station-14-launcher/SS14.Launcher/Models/Updater.cs:line 833
   at SS14.Launcher.Models.Updater.InstallEnginesForVersion(SqliteConnection con, Lazy`1 moduleManifest, Int64 versionRowId, CancellationToken cancel) in /run/build/space-station-14-launcher/SS14.Launcher/Models/Updater.cs:line 291
   at SS14.Launcher.Models.Updater.RunUpdate(ServerBuildInformation buildInfo, CancellationToken cancel) in /run/build/space-station-14-launcher/SS14.Launcher/Models/Updater.cs:line 135
   at SS14.Launcher.Models.Updater.GuardUpdateAsync[T](Func`1 func) in /run/build/space-station-14-launcher/SS14.Launcher/Models/Updater.cs:line 90
   at SS14.Launcher.Models.Updater.RunUpdateForLaunchAsync(ServerBuildInformation buildInformation, CancellationToken cancel) in /run/build/space-station-14-launcher/SS14.Launcher/Models/Updater.cs:line 66
   at SS14.Launcher.Models.Connector.RunUpdateAsync(ServerInfo info, CancellationToken cancel) in /run/build/space-station-14-launcher/SS14.Launcher/Models/Connector.cs:line 437
   at SS14.Launcher.Models.Connector.ConnectInternalAsync(String address, CancellationToken cancel) in /run/build/space-station-14-launcher/SS14.Launcher/Models/Connector.cs:line 131
   at SS14.Launcher.Models.Connector.Connect(String address, CancellationToken cancel) in /run/build/space-station-14-launcher/SS14.Launcher/Models/Connector.cs:line 78
```

With all this in mind, we would like to suggest that you either redefine the original SS14 URLs to your own, which we could mirror for the CIS community ("RU", "KZ", "BY", "UZ", "AZ", "TJ", "TM", "KG", "AM" countries) or raise such mirrors for CIS users ourselves.

## In this PR 

We suggest add functioin allow to override robust builds url (`RobustBuildsURL`) for read this from ext. env. That's help us create mirror for the CIS comm. in the laucnher.

## P.s.

If this problem is ignored, unfortunately, some players will not be able to play ss14 due to technical difficulties, which will lead to a decline in the online ss14 project as a whole. We hope for your cooperation. If you have any questions, we are always ready to answer at any time.

Thank you in advance,
Sincerely, the administrator of one of the top servers of the ss14 project