### PR TITLE
Fix fallbacks not being used in the launcher on 500 class errors

### DIFF
--- a/SS14.Launcher/ConfigConstants.cs
+++ b/SS14.Launcher/ConfigConstants.cs
@@ -11,7 +11,7 @@ public static class ConfigConstants
     // Refresh login tokens if they're within <this much> of expiry.
     public static readonly TimeSpan TokenRefreshThreshold = TimeSpan.FromDays(15);
 
-    // If the user leaves the launcher running for absolute ages, this is how often we'll update his login tokens.
+    // If the user leaves the launcher running for absolute ages, this is how often we'll update their login tokens.
     public static readonly TimeSpan TokenRefreshInterval = TimeSpan.FromDays(7);
 
     // The amount of time before a server is considered timed out for status checks.

--- a/SS14.Launcher/Models/Logins/LoginManager.cs
+++ b/SS14.Launcher/Models/Logins/LoginManager.cs
@@ -86,7 +86,7 @@ public sealed class LoginManager : ReactiveObject
     public async Task Initialize()
     {
         // Set up timer so that if the user leaves their launcher open for a month or something
-        // his tokens don't expire.
+        // their tokens don't expire.
         _timer = DispatcherTimer.Run(() =>
         {
             async void Impl()

--- a/SS14.Launcher/Utility/UrlFallbackSet.cs
+++ b/SS14.Launcher/Utility/UrlFallbackSet.cs
@@ -109,6 +109,8 @@ public sealed class UrlFallbackSet
             cancel
         ).ConfigureAwait(false);
 
+        response.EnsureSuccessStatusCode();
+
         return response;
     }
 

--- a/SS14.Launcher/Utility/UrlFallbackSet.cs
+++ b/SS14.Launcher/Utility/UrlFallbackSet.cs
@@ -109,7 +109,8 @@ public sealed class UrlFallbackSet
             cancel
         ).ConfigureAwait(false);
 
-        response.EnsureSuccessStatusCode();
+        if ((int)response.StatusCode >= 500)
+            throw new HttpRequestException($"Server returned {response.StatusCode} for {message.RequestUri}");
 
         return response;
     }


### PR DESCRIPTION
This is really the best way i can think of solving the issue from #252, a 500 is 100% something going wrong and the fallback needs to be attempted.

If you have better suggestion to make this more reliable please suggest it.

I think if both main and fallback 500 here the launcher will crash again though...
