### PR TITLE
Update nix build to v0.36.1 and cleanup

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1747046372,
-        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
+        "lastModified": 1764712249,
+        "narHash": "sha256-DhsrZsMebdvpjZC2EzPsqiLGI84tD7kZz7zc6tTCmqg=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
+        "rev": "3b279e4317ccfa4865356387935310531357d919",
         "type": "github"
       },
       "original": {
@@ -18,11 +18,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1760504863,
-        "narHash": "sha256-h13YFQMi91nXkkRoJMIfezorz5SbD6849jw5L0fjK4I=",
+        "lastModified": 1764642553,
+        "narHash": "sha256-mvbFFzVBhVK1FjyPHZGMAKpNiqkr7k++xIwy+p/NQvA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "82c2e0d6dde50b17ae366d2aa36f224dc19af469",
+        "rev": "f720de59066162ee879adcc8c79e15c51fe6bfb4",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -12,12 +12,12 @@
     let
       forAllSystems = function:
         nixpkgs.lib.genAttrs [ "x86_64-linux" ] # TODO: aarch64-linux support
-          (system: function (import nixpkgs { inherit system; }));
+          (system: function system (import nixpkgs { inherit system; }));
     in
     {
 
-      packages = forAllSystems (pkgs: {
-        default = self.packages.${pkgs.system}.space-station-14-launcher;
+      packages = forAllSystems (system: pkgs: {
+        default = self.packages.${system}.space-station-14-launcher;
         space-station-14-launcher =
           pkgs.callPackage ./nix/package.nix { };
       });
@@ -26,13 +26,13 @@
         default = self.overlays.space-station-14-launcher;
         space-station-14-launcher = final: prev: {
           space-station-14-launcher =
-            self.packages.${prev.system}.space-station-14-launcher;
+            self.packages.${prev.stdenv.hostPlatform.system}.space-station-14-launcher;
         };
       };
 
-      apps = forAllSystems (pkgs:
-        let pkg = self.packages.${pkgs.system}.space-station-14-launcher; in {
-          default = self.apps.${pkgs.system}.space-station-14-launcher;
+      apps = forAllSystems (system: pkgs:
+        let pkg = self.packages.${system}.space-station-14-launcher; in {
+          default = self.apps.${system}.space-station-14-launcher;
           space-station-14-launcher = {
             type = "app";
             program = "${pkg}/bin/${pkg.meta.mainProgram}";
@@ -40,11 +40,11 @@
           fetch-deps = {
             type = "app";
             program = toString
-              self.packages.${pkgs.system}.space-station-14-launcher.passthru.fetch-deps;
+              self.packages.${system}.space-station-14-launcher.passthru.fetch-deps;
           };
         });
 
-      formatter = forAllSystems (pkgs: pkgs.nixpkgs-fmt);
+      formatter = forAllSystems (_: pkgs: pkgs.nixpkgs-fmt);
 
     };
 }

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -16,21 +16,9 @@
   libXcursor,
   libXext,
   libXrandr,
-  fontconfig,
-  glew,
-  glfw,
-  glibc,
   libGL,
   freetype,
-  openal,
-  fluidsynth,
-  gtk3,
-  pango,
-  atk,
-  cairo,
-  zlib,
   glib,
-  gdk-pixbuf,
   alsa-lib,
   libjack2,
   pipewire,
@@ -46,7 +34,7 @@
   soundfont-path ? "${soundfont-fluid}/share/soundfonts/FluidR3_GM2-2.sf2",
 }:
 let
-  version = "0.35.0";
+  version = "0.36.1";
   pname = "space-station-14-launcher";
 in
 buildDotnetModule rec {
@@ -60,7 +48,7 @@ buildDotnetModule rec {
     owner = "space-wizards";
     repo = "SS14.Launcher";
     rev = "v${version}";
-    hash = "sha256-8YDlX5GwL5S/gdjIWOa48sEGA/sMEYZvy2FTWSPO+Ug=";
+    hash = "sha256-6wH2CkTuwy+a3EGpKrdLDsIaQ7oZc2I1OLdmAREMazw=";
     fetchSubmodules = true;
   };
 
@@ -82,10 +70,10 @@ buildDotnetModule rec {
   dotnet-sdk =
     with dotnetCorePackages;
     combinePackages [
-      sdk_9_0
+      sdk_10_0
       sdk_8_0
     ];
-  dotnet-runtime = dotnetCorePackages.runtime_9_0;
+  dotnet-runtime = dotnetCorePackages.runtime_10_0;
 
   dotnetFlags = [
     "-p:FullRelease=true"
@@ -94,48 +82,14 @@ buildDotnetModule rec {
   ];
 
   nativeBuildInputs = [
-    wrapGAppsHook3
     iconConvTools
     copyDesktopItems
   ];
 
-  LD_LIBRARY_PATH = lib.makeLibraryPath [
-    fontconfig
-    libX11
-    libICE
-    libSM
-    libXi
-    libXcursor
-    libXext
-    libXrandr
-
-    glfw
-    glibc
-    libGL
-    openal
-    freetype
-    fluidsynth
-  ];
-
   runtimeDeps = [
-    # Required by the game.
-    glfw
-    glibc
     libGL
-    openal
     freetype
-    fluidsynth
-
-    # Needed for file dialogs.
-    gtk3
-    pango
-    cairo
-    atk
-    zlib
     glib
-    gdk-pixbuf
-
-    # Avalonia UI dependencies.
     libX11
     libICE
     libSM
@@ -143,8 +97,6 @@ buildDotnetModule rec {
     libXcursor
     libXext
     libXrandr
-    fontconfig
-    glew
 
     # TODO: Figure out dependencies for CEF support.
   ]


### PR DESCRIPTION
- Updated flake lockfile
- Removed usage of `pkgs.system` from `flake.nix`
- Updated to dotnet 10 alongside the v0.36.1 release
- Removed redundant/bundled libraries that were leftover from older releases

Idk why `freetype` and `fluidsynth` need to included despite the fact they should be in `Robust.Natives`  but oh well.