### PR TITLE
Nix: Fix file selection in the client under NixOS

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -27,6 +27,7 @@
   libxkbcommon,
   wayland,
   fontconfig,
+  zenity,
   alsaSupport ? stdenv.hostPlatform.isLinux,
   jackSupport ? stdenv.hostPlatform.isLinux,
   pipewireSupport ? stdenv.hostPlatform.isLinux,
@@ -100,6 +101,7 @@ buildDotnetModule rec {
     wayland
     fontconfig.lib
   ]
+  ++ lib.optional stdenv.hostPlatform.isLinux zenity
   ++ lib.optional alsaSupport alsa-lib
   ++ lib.optional jackSupport libjack2
   ++ lib.optional pipewireSupport pipewire
@@ -108,7 +110,12 @@ buildDotnetModule rec {
   # ${soundfont-path} is escaped here:
   # https://github.com/NixOS/nixpkgs/blob/d29975d32b1dc7fe91d5cb275d20f8f8aba399ad/pkgs/build-support/setup-hooks/make-wrapper.sh#L126C35-L126C45
   # via https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html under ${parameter@operator}
-  makeWrapperArgs = [ ''--set ROBUST_SOUNDFONT_OVERRIDE ${soundfont-path}'' ];
+  makeWrapperArgs = [
+      "--set ROBUST_SOUNDFONT_OVERRIDE ${soundfont-path}"
+  ] ++ lib.optionals stdenv.hostPlatform.isLinux [
+      "--suffix PATH : ${lib.getBin zenity}/bin"
+      "--set SDL_FILE_DIALOG_DRIVER zenity"
+  ];
 
   executables = [ "SS14.Launcher" ];
 


### PR DESCRIPTION
For some reason, the portal method does not work for me, to pick MIDI file to play. I hence opted to make use of zenity, which just mean that I needed to provide the good program in PATH, that SDL support.

I don’t really know why XDG portal does not work, thought. But this work just as good.

(ps: file picker in the launcher itself (for replay) already worked and still work)

I don’t know if this Nix file work on MacOS. But I have no MacOS machine to test it, so I made sure to only enable it on Linux.