### PR TITLE
Reallow auth override on release, but show a warning instead

### DIFF
--- a/SS14.Launcher/App.xaml.cs
+++ b/SS14.Launcher/App.xaml.cs
@@ -153,11 +153,9 @@ public class App : Application
         Locator.CurrentMutable.RegisterConstant(lc);
         msgr.StartServerTask(lc);
 
-        // Check if auth URL is overridden
-        var authOverride = Environment.GetEnvironmentVariable("SS14_LAUNCHER_OVERRIDE_AUTH");
-        if (!string.IsNullOrEmpty(authOverride))
+        if (ConfigConstants.IsAuthOverride)
         {
-            Log.Information("Auth URL override detected: {AuthUrl}.", authOverride);
+            Log.Information("Auth URL override detected: {AuthUrl}.", ConfigConstants.AuthUrl);
             viewModel.ShouldShowAuthOverrideWarning = true;
             viewModel.StartAuthOverrideCountdown();
         }

--- a/SS14.Launcher/App.xaml.cs
+++ b/SS14.Launcher/App.xaml.cs
@@ -153,6 +153,15 @@ public class App : Application
         Locator.CurrentMutable.RegisterConstant(lc);
         msgr.StartServerTask(lc);
 
+        // Check if auth URL is overridden
+        var authOverride = Environment.GetEnvironmentVariable("SS14_LAUNCHER_OVERRIDE_AUTH");
+        if (!string.IsNullOrEmpty(authOverride))
+        {
+            Log.Information("Auth URL override detected: {AuthUrl}.", authOverride);
+            viewModel.ShouldShowAuthOverrideWarning = true;
+            viewModel.StartAuthOverrideCountdown();
+        }
+
         window.Show();
     }
 

--- a/SS14.Launcher/Assets/Locale/de/text.ftl
+++ b/SS14.Launcher/Assets/Locale/de/text.ftl
@@ -140,6 +140,8 @@ login-forgot-error = Fehler
 # Strings for the "login" view on login
 login-login-title = Anmeldung
 # Strings for the "login" view on login
+login-login-auth-server-changed = Auth Server hat sich geändert
+# Strings for the "login" view on login
 login-login-username-watermark = Nutzername oder E-Mail
 # Strings for the "login" view on login
 login-login-password-watermark = Passwort
@@ -542,3 +544,10 @@ server-entry-round-time =
     }
 tab-servers-table-round-time = Zeit
 tab-options-desc-incompatible = Diese Option ist mit deiner Plattform nicht kompatibel und wurde deaktiviert.
+# Strings for the general main window layout of the launcher
+main-window-auth-override-title = Die Authentifizierungs-Server-URL hat sich geändert
+# Strings for the general main window layout of the launcher
+main-window-auth-override-desc =
+    Wenn du dies nicht absichtlich geändert hast, könnte jemand Böswilliges versuchen, auf deine Anmeldedaten zuzugreifen. Indem du dieses Popup schließt, erklärst du dich selbst für verantwortlich für deine eigene Sicherheit und erhältst keinen Support.
+# Strings for the general main window layout of the launcher
+main-window-auth-override-acknowledge = Ich bestätige

--- a/SS14.Launcher/Assets/Locale/en-US/text.ftl
+++ b/SS14.Launcher/Assets/Locale/en-US/text.ftl
@@ -192,6 +192,10 @@ main-window-busy-checking-login-status = Refreshing login status…
 main-window-busy-checking-account-status = Checking account status
 main-window-error-connecting-auth-server = Error connecting to authentication server
 main-window-error-unknown = Unknown error occurred
+main-window-auth-override-title = The authentication server URL has changed
+main-window-auth-override-desc =
+     If you don't remember changing this, it's possible someone malicious may be trying to snoop on your credentials. By closing this popup, you agree you are responsible for your own security, and will not be provided support.
+main-window-auth-override-acknowledge = I acknowledge
 
 ## Long region names for server tag filters (shown in tooltip)
 

--- a/SS14.Launcher/Assets/Locale/en-US/text.ftl
+++ b/SS14.Launcher/Assets/Locale/en-US/text.ftl
@@ -134,6 +134,7 @@ login-forgot-error = Error
 ## Strings for the "login" view on login
 
 login-login-title = Log in
+login-login-auth-server-changed = Auth server has changed
 login-login-username-watermark = Username or email
 login-login-password-watermark = Password
 login-login-show-password = Show Password

--- a/SS14.Launcher/Assets/Locale/nl/text.ftl
+++ b/SS14.Launcher/Assets/Locale/nl/text.ftl
@@ -179,6 +179,8 @@ login-forgot-error = Fout
 # Strings for the "login" view on login
 login-login-title = Inloggen
 # Strings for the "login" view on login
+login-login-auth-server-changed = Authenticatieserver is veranderd
+# Strings for the "login" view on login
 login-login-username-watermark = Gebruikersnaam of e-mail
 # Strings for the "login" view on login
 login-login-password-watermark = Wachtwoord
@@ -549,4 +551,11 @@ server-entry-status-lobby = Lobby
 connecting-status-update-error-unknown = Onbekend
 main-window-rosetta-accept = Ga verder
 button-done = Klaar!
+# Strings for the general main window layout of the launcher
+main-window-auth-override-title = De authenticatieserver-URL is veranderd
+# Strings for the general main window layout of the launcher
+main-window-auth-override-desc =
+    Als je dit niet opzettelijk hebt veranderd, is het mogelijk dat iemand met slechte bedoelingen jouw inloggegevens probeert in te zien. Door dit venster te sluiten, ben je zelf verantwoordelijk voor jouw eigen veiligheid en ontvang je geen ondersteuning.
+# Strings for the general main window layout of the launcher
+main-window-auth-override-acknowledge = Ga verder
 tab-options-clear-content-close-client = Sluit draaiende spellen eerst

--- a/SS14.Launcher/ConfigConstants.cs
+++ b/SS14.Launcher/ConfigConstants.cs
@@ -39,6 +39,7 @@ public static class ConfigConstants
     public const string DownloadUrl = "https://spacestation14.com/about/nightlies/";
     public const string NewsFeedUrl = "https://spacestation14.com/post/index.xml";
     public const string TranslateUrl = "https://docs.spacestation14.com/en/general-development/contributing-translations.html";
+    public static bool IsAuthOverride;
 
     private static readonly UrlFallbackSet RobustBuildsBaseUrl = new([
         "https://robust-builds.cdn.spacestation14.com/",
@@ -66,6 +67,9 @@ public static class ConfigConstants
     {
         var envVarAuthUrl = Environment.GetEnvironmentVariable("SS14_LAUNCHER_OVERRIDE_AUTH");
         if (!string.IsNullOrEmpty(envVarAuthUrl))
+        {
             AuthUrl = new UrlFallbackSet([envVarAuthUrl]);
+            IsAuthOverride = true;
+        }
     }
 }

--- a/SS14.Launcher/ConfigConstants.cs
+++ b/SS14.Launcher/ConfigConstants.cs
@@ -69,7 +69,9 @@ public static class ConfigConstants
         if (!string.IsNullOrEmpty(envVarAuthUrl))
         {
             AuthUrl = new UrlFallbackSet([envVarAuthUrl]);
+#if !DEBUG
             IsAuthOverride = true;
+#endif
         }
     }
 }

--- a/SS14.Launcher/ConfigConstants.cs
+++ b/SS14.Launcher/ConfigConstants.cs
@@ -62,12 +62,10 @@ public static class ConfigConstants
 
     public const string FallbackUsername = "JoeGenero";
 
-#if DEBUG
     static ConfigConstants()
     {
         var envVarAuthUrl = Environment.GetEnvironmentVariable("SS14_LAUNCHER_OVERRIDE_AUTH");
         if (!string.IsNullOrEmpty(envVarAuthUrl))
             AuthUrl = new UrlFallbackSet([envVarAuthUrl]);
     }
-#endif
 }

--- a/SS14.Launcher/ViewModels/Login/LoginViewModel.cs
+++ b/SS14.Launcher/ViewModels/Login/LoginViewModel.cs
@@ -22,6 +22,8 @@ public class LoginViewModel : BaseLoginViewModel
     [Reactive] public bool IsInputValid { get; private set; }
     [Reactive] public bool IsPasswordVisible { get; set; }
 
+    public bool IsAuthServerOverridden => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SS14_LAUNCHER_OVERRIDE_AUTH"));
+
     public LoginViewModel(MainWindowLoginViewModel parentVm, AuthApi authApi,
         LoginManager loginMgr, DataManager dataManager) : base(parentVm)
     {

--- a/SS14.Launcher/ViewModels/Login/LoginViewModel.cs
+++ b/SS14.Launcher/ViewModels/Login/LoginViewModel.cs
@@ -22,8 +22,6 @@ public class LoginViewModel : BaseLoginViewModel
     [Reactive] public bool IsInputValid { get; private set; }
     [Reactive] public bool IsPasswordVisible { get; set; }
 
-    public bool IsAuthServerOverridden => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SS14_LAUNCHER_OVERRIDE_AUTH"));
-
     public LoginViewModel(MainWindowLoginViewModel parentVm, AuthApi authApi,
         LoginManager loginMgr, DataManager dataManager) : base(parentVm)
     {

--- a/SS14.Launcher/ViewModels/MainWindowViewModel.cs
+++ b/SS14.Launcher/ViewModels/MainWindowViewModel.cs
@@ -8,6 +8,7 @@ using System.Reactive.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Avalonia.Platform.Storage;
+using Avalonia.Threading;
 using DynamicData;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
@@ -37,6 +38,8 @@ public sealed class MainWindowViewModel : ViewModelBase, IErrorOverlayOwner
 
     public DataManager Cfg => _cfg;
     [Reactive] public bool OutOfDate { get; private set; }
+
+    private IDisposable? _authOverrideCountdownTimer;
 
     public HomePageViewModel HomeTab { get; }
     public ServerListTabViewModel ServersTab { get; }
@@ -138,6 +141,9 @@ public sealed class MainWindowViewModel : ViewModelBase, IErrorOverlayOwner
     public ICVarEntry<bool> HasDismissedEarlyAccessWarning => Cfg.GetCVarEntry(CVars.HasDismissedEarlyAccessWarning);
     public bool ShouldShowIntelDegradationWarning => IsVulnerableToIntelDegradation(_cfg);
     public bool ShouldShowRosettaWarning => IsAppleSiliconInRosetta(_cfg);
+    [Reactive] public bool ShouldShowAuthOverrideWarning { get; set; }
+    [Reactive] public int AuthOverrideCountdown { get; private set; } = 5;
+    [Reactive] public bool IsAuthOverrideButtonEnabled { get; private set; }
 
     public string Version => $"v{LauncherVersion.Version}";
 
@@ -222,6 +228,33 @@ public sealed class MainWindowViewModel : ViewModelBase, IErrorOverlayOwner
         Cfg.SetCVar(CVars.HasDismissedRosettaWarning, true);
         Cfg.CommitConfig();
         this.RaisePropertyChanged(nameof(ShouldShowRosettaWarning));
+    }
+
+    public void DismissAuthOverridePressed()
+    {
+        _authOverrideCountdownTimer?.Dispose();
+        _authOverrideCountdownTimer = null;
+        ShouldShowAuthOverrideWarning = false;
+    }
+
+    public void StartAuthOverrideCountdown()
+    {
+        AuthOverrideCountdown = 5;
+        IsAuthOverrideButtonEnabled = false;
+        _authOverrideCountdownTimer?.Dispose();
+
+        _authOverrideCountdownTimer = DispatcherTimer.Run(() =>
+        {
+            AuthOverrideCountdown--;
+            if (AuthOverrideCountdown <= 0)
+            {
+                IsAuthOverrideButtonEnabled = true;
+                _authOverrideCountdownTimer?.Dispose();
+                _authOverrideCountdownTimer = null;
+                return false;
+            }
+            return true;
+        }, TimeSpan.FromSeconds(1), DispatcherPriority.Normal);
     }
 
     public void SelectTabServers()

--- a/SS14.Launcher/Views/Login/LoginView.xaml
+++ b/SS14.Launcher/Views/Login/LoginView.xaml
@@ -4,7 +4,6 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vml="clr-namespace:SS14.Launcher.ViewModels.Login;assembly=SS14.Launcher"
              xmlns:loc="clr-namespace:SS14.Launcher.Localization"
-             xmlns:login="clr-namespace:SS14.Launcher.ViewModels.Login"
              xmlns:local="clr-namespace:SS14.Launcher"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="SS14.Launcher.Views.Login.LoginView"

--- a/SS14.Launcher/Views/Login/LoginView.xaml
+++ b/SS14.Launcher/Views/Login/LoginView.xaml
@@ -15,7 +15,7 @@
     <TextBlock HorizontalAlignment="Center" DockPanel.Dock="Top" Classes="NanoHeadingMedium" Text="{loc:Loc login-login-title}" />
 
     <TextBlock HorizontalAlignment="Center" DockPanel.Dock="Top" Foreground="Red" Margin="0, 10, 0, 0"
-               Text="Auth server has changed" IsVisible="{Binding IsAuthServerOverridden}" />
+               Text="{loc:Loc login-login-auth-server-changed}" IsVisible="{Binding IsAuthServerOverridden}" />
 
     <TextBox DockPanel.Dock="Top" Name="NameBox" MaxWidth="300" Margin="0, 10, 0, 0"
              Watermark="{loc:Loc login-login-username-watermark}"

--- a/SS14.Launcher/Views/Login/LoginView.xaml
+++ b/SS14.Launcher/Views/Login/LoginView.xaml
@@ -14,6 +14,9 @@
   <DockPanel LastChildFill="False">
     <TextBlock HorizontalAlignment="Center" DockPanel.Dock="Top" Classes="NanoHeadingMedium" Text="{loc:Loc login-login-title}" />
 
+    <TextBlock HorizontalAlignment="Center" DockPanel.Dock="Top" Foreground="Red" Margin="0, 10, 0, 0"
+               Text="Auth server has changed" IsVisible="{Binding IsAuthServerOverridden}" />
+
     <TextBox DockPanel.Dock="Top" Name="NameBox" MaxWidth="300" Margin="0, 10, 0, 0"
              Watermark="{loc:Loc login-login-username-watermark}"
              Text="{Binding EditingUsername, Mode=TwoWay}" IsEnabled="{Binding !Busy}" />

--- a/SS14.Launcher/Views/Login/LoginView.xaml
+++ b/SS14.Launcher/Views/Login/LoginView.xaml
@@ -4,6 +4,8 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vml="clr-namespace:SS14.Launcher.ViewModels.Login;assembly=SS14.Launcher"
              xmlns:loc="clr-namespace:SS14.Launcher.Localization"
+             xmlns:login="clr-namespace:SS14.Launcher.ViewModels.Login"
+             xmlns:local="clr-namespace:SS14.Launcher"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="SS14.Launcher.Views.Login.LoginView"
              Name="Login">
@@ -15,7 +17,7 @@
     <TextBlock HorizontalAlignment="Center" DockPanel.Dock="Top" Classes="NanoHeadingMedium" Text="{loc:Loc login-login-title}" />
 
     <TextBlock HorizontalAlignment="Center" DockPanel.Dock="Top" Foreground="Red" Margin="0, 10, 0, 0"
-               Text="{loc:Loc login-login-auth-server-changed}" IsVisible="{Binding IsAuthServerOverridden}" />
+               Text="{loc:Loc login-login-auth-server-changed}" IsVisible="{Binding Source={x:Static local:ConfigConstants.IsAuthOverride}}" />
 
     <TextBox DockPanel.Dock="Top" Name="NameBox" MaxWidth="300" Margin="0, 10, 0, 0"
              Watermark="{loc:Loc login-login-username-watermark}"

--- a/SS14.Launcher/Views/MainWindowContent.xaml
+++ b/SS14.Launcher/Views/MainWindowContent.xaml
@@ -146,6 +146,19 @@
       </StackPanel>
     </ContentControl>
 
+    <ContentControl Classes="OverlayBox" IsVisible="{Binding ShouldShowAuthOverrideWarning}">
+      <StackPanel Orientation="Vertical">
+        <TextBlock HorizontalAlignment="Center" Classes="NanoHeadingMedium" Foreground="Red"
+                   Text="The authentication server URL has changed" />
+        <TextBlock Margin="0, 10" TextAlignment="Center" MaxWidth="450" TextWrapping="Wrap"
+                   Text="If you don't remember changing this, it's possible someone malicious may be trying to snoop on your credentials. By closing this popup, you agree you are responsible for your own security, and will not be provided support." />
+        <Button Content="{Binding AuthOverrideCountdown, StringFormat='I acknowledge ({0}s)'}"
+                Command="{Binding DismissAuthOverridePressed}"
+                IsEnabled="{Binding IsAuthOverrideButtonEnabled}"
+                HorizontalAlignment="Center" />
+      </StackPanel>
+    </ContentControl>
+
     <!--
       Literally just keep piling them on it doesn't matter.
       This is way easier than coming up with some horribly over-engineered solution.

--- a/SS14.Launcher/Views/MainWindowContent.xaml
+++ b/SS14.Launcher/Views/MainWindowContent.xaml
@@ -149,9 +149,9 @@
     <ContentControl Classes="OverlayBox" IsVisible="{Binding ShouldShowAuthOverrideWarning}">
       <StackPanel Orientation="Vertical">
         <TextBlock HorizontalAlignment="Center" Classes="NanoHeadingMedium" Foreground="Red"
-                   Text="The authentication server URL has changed" />
+                   Text="{loc:Loc main-window-auth-override-title}" />
         <TextBlock Margin="0, 10" TextAlignment="Center" MaxWidth="450" TextWrapping="Wrap"
-                   Text="If you don't remember changing this, it's possible someone malicious may be trying to snoop on your credentials. By closing this popup, you agree you are responsible for your own security, and will not be provided support." />
+                   Text="{loc:Loc main-window-auth-override-desc}" />
         <Button Content="{Binding AuthOverrideCountdown, StringFormat='I acknowledge ({0}s)'}"
                 Command="{Binding DismissAuthOverridePressed}"
                 IsEnabled="{Binding IsAuthOverrideButtonEnabled}"


### PR DESCRIPTION
Instead of just banning people from using whatever server they want, it's better to just show a popup so you can ignore people being dumb

The text is kinda a placeholder since idk what would fit best
<img width="1000" height="625" alt="image" src="https://github.com/user-attachments/assets/c2d59a16-bf9b-4674-bef3-173cad3d04d7" />

This also writes an entry into the log, so if any logs are provided for issues related to auth and this pops up you know exactly whats going on
<img width="666" height="48" alt="image" src="https://github.com/user-attachments/assets/3a8aa875-01e0-4563-a87c-11b631b4640e" />
