### PR TITLE
Log exceptions on crash.

### DIFF
--- a/SS14.Launcher/App.xaml.cs
+++ b/SS14.Launcher/App.xaml.cs
@@ -155,7 +155,7 @@ public class App : Application
 
         if (ConfigConstants.IsAuthOverride)
         {
-            Log.Information("Auth URL override detected: {AuthUrl}.", ConfigConstants.AuthUrl);
+            Log.Information("Auth URL override detected: {AuthUrl}.", ConfigConstants.AuthUrl.Urls);
             viewModel.ShouldShowAuthOverrideWarning = true;
             viewModel.StartAuthOverrideCountdown();
         }

--- a/SS14.Launcher/Program.cs
+++ b/SS14.Launcher/Program.cs
@@ -122,6 +122,7 @@ internal static class Program
         catch (Exception ex)
         {
             Log.Error(ex, "Launcher crashed with unhandled exception(s).");
+            throw;
         }
         finally
         {

--- a/SS14.Launcher/Program.cs
+++ b/SS14.Launcher/Program.cs
@@ -119,6 +119,10 @@ internal static class Program
         {
             BuildAvaloniaApp(cfg).StartWithClassicDesktopLifetime(args);
         }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Launcher crashed with unhandled exception(s).");
+        }
         finally
         {
             Log.CloseAndFlush();


### PR DESCRIPTION
Adds a handler for Exception to Main.
Also changes the log coming from auth url overrides to show the actual auth url. This was previously just showing the location of the variable which seemed unhelpful. Though maybe that was intended for privacy purposes? Although at that point should this even log a variable?

I have concerns this would even be deemed appropriate but I figured I'd shoot it out there and see what happens.
The throw statement that follows the log message is there to allow debuggers to pickup on the error. Also prevents the launcher 
from hanging after it logs the message... for some reason?

Reason for doing this now is that I've seen a few launcher crashes which I suspect were down to domain resolution. See (#292)