### PR TITLE
Desktop entry additions & cleanup

### DIFF
--- a/PublishFiles/SS14.desktop
+++ b/PublishFiles/SS14.desktop
@@ -1,21 +1,25 @@
 #!/usr/bin/env xdg-open
 [Desktop Entry]
+Categories=Game
 Comment=A multiplayer disaster simulator
 Encoding=UTF-8
-Exec=./SS14.Launcher %u
+Exec=SS14.Launcher %u
 GenericName[en_US]=Space Station 14
 GenericName=Space Station 14 Launcher
-Icon=SS14.ico
+Icon=SS14
+Keywords=game;gaming;launcher;multiplayer;ss14
 MimeType=
 Name[en_US]=Space Station 14 Launcher
 Name=Space Station 14 Launcher
 NoDisplay=false
 Path=
 PrefersNonDefaultGPU=false
+SingleMainWindow=true
 StartupNotify=true
+StartupWMClass=SS14.Launcher
 Terminal=false
 TerminalOptions=
 Type=Application
-Version=1.0
+Version=1.5
 X-KDE-SubstituteUID=false
 X-KDE-Username=


### PR DESCRIPTION
Adds `Categories` for `Game` (which I'm surprised was in the nix package but not here)

`Exec` is no longer a relative path as the [spec](https://specifications.freedesktop.org/desktop-entry/1.5/exec-variables.html) does not support that anyways:
>  The executable program can either be specified with its **full path** or with the name of the executable only.

`Icon`'s extension is removed as from what I understand from reading http://freedesktop.org/wiki/Standards/icon-theme-spec this is the name of the icon that is searched and not the filename (unless its a absolute path)

`SingleMainWindow=true` should be self evident as SS14.Launcher will not let itself be launched multiple times

`Version` bumped to `1.5` since `SingleMainWindow` needs it (and `PrefersNonDefaultGPU` is also a key added in `1.4` so it was outdated already)