### PR TITLE
Rename auth override value

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -10,4 +10,4 @@ This is the launcher you should be using to connect to SS14 servers. Server brow
 
 Useful environment variables for development:
 * `SS14_LAUNCHER_APPDATA_NAME=launcherTest` to change the user data directories the launcher stores its data in. This can be useful to avoid breaking your "normal" SS14 launcher data while developing something.
-* `SS14_LAUNCHER_OVERRIDE_AUTH=https://.../` to change the auth API URL to test against a local dev version of the API.
+* `SS14_LAUNCHER_OVERRIDE_AUTH_URL=https://.../` to change the auth API URL to test against a local dev version of the API.

--- a/SS14.Launcher/ConfigConstants.cs
+++ b/SS14.Launcher/ConfigConstants.cs
@@ -66,7 +66,7 @@ public static class ConfigConstants
 
     static ConfigConstants()
     {
-        var envVarAuthUrl = Environment.GetEnvironmentVariable("SS14_LAUNCHER_OVERRIDE_AUTH");
+        var envVarAuthUrl = Environment.GetEnvironmentVariable("SS14_LAUNCHER_OVERRIDE_AUTH_URL");
         if (!string.IsNullOrEmpty(envVarAuthUrl))
         {
             Log.Information("Auth override envar detected. Switching to: {AuthUrl}", envVarAuthUrl);


### PR DESCRIPTION
Renames the auth override environment variable name from SS14_LAUNCHER_OVERRIDE_AUTH to SS14_LAUNCHER_OVERRIDE_AUTH_URL
This is to ignore values previously set by players during the auth changes, which might be causing issues with the popup appearing again for them and they are unable to fix it